### PR TITLE
RDKEMW-2214: Generic way of display info plugin for soc abstraction implementations of displayinfosoc library linking recipe changes.

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -30,7 +30,7 @@ EXTRA_OECMAKE += " -DBUILD_ENABLE_APP_CONTROL_AUDIOPORT_INIT=ON "
 EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'link_localtime', ' -DBUILD_ENABLE_LINK_LOCALTIME=ON', '',d)}"
 
 DEPENDS += "wpeframework wpeframework-tools-native"
-RDEPENDS:${PN} += " wpeframework"
+RDEPENDS:${PN} += "wpeframework"
 
 TARGET_LDFLAGS += " -Wl,--no-as-needed -ltelemetry_msgsender -Wl,--as-needed "
 


### PR DESCRIPTION
**Reason for change:** Added the soc abstraction implementations of displayinfosoc library linking recipe changes.
**Tickets:** RDKEMW-2214 & RDKVREFPLT-4928
**Test Procedure:** Build and verify the displayinfo plugin.
**Risks:** Medium.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com