### PR TITLE
RDKTV-35245 : Delete sqlite temporary data

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -14,6 +14,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://rdkservices.ini \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
            file://0001-RDK-41681-PR4013.patch \
+           file://0001-Rdktv-35245-main-6149.patch \
           "
 
 # Release version - 1.1.7

--- a/recipes-extended/entservices/files/0001-Rdktv-35245-main-6149.patch
+++ b/recipes-extended/entservices/files/0001-Rdktv-35245-main-6149.patch
@@ -1,0 +1,65 @@
+From 90aae99a0d554f41c8961dd06d3fea0a030661f5 Mon Sep 17 00:00:00 2001
+From: Nikita Poltorapavlo <Nikita_Poltorapavlo2@cable.comcast.com>
+Date: Wed, 19 Mar 2025 17:20:02 +0200
+Subject: [PATCH] Rdktv 35245 main (#6149)
+
+* RDKTV-35245 : Delete sqlite temporary data (#6121)
+
+Reason for change: Temporary -journal folder created by sqlite
+blocks it from creating a new database after reset.
+Test Procedure: None
+Risks: None
+Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>
+
+* update changelog and api version
+---
+ PersistentStore/PersistentStore.cpp |  2 +-
+ PersistentStore/sqlite/Store2.h     | 12 ++++++++++++
+ 2 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/PersistentStore/PersistentStore.cpp b/PersistentStore/PersistentStore.cpp
+index 99ddcadf..caae947e 100644
+--- a/PersistentStore/PersistentStore.cpp
++++ b/PersistentStore/PersistentStore.cpp
+@@ -22,7 +22,7 @@
+ 
+ #define API_VERSION_NUMBER_MAJOR 2
+ #define API_VERSION_NUMBER_MINOR 0
+-#define API_VERSION_NUMBER_PATCH 1
++#define API_VERSION_NUMBER_PATCH 3
+ 
+ namespace WPEFramework {
+ 
+diff --git a/PersistentStore/sqlite/Store2.h b/PersistentStore/sqlite/Store2.h
+index c2f031f6..ea225f88 100644
+--- a/PersistentStore/sqlite/Store2.h
++++ b/PersistentStore/sqlite/Store2.h
+@@ -88,6 +88,7 @@ namespace Plugin {
+                 , _maxValue(maxValue)
+                 , _limit(limit)
+             {
++                TempDirectoryCheck();
+                 IntegrityCheck();
+                 Open();
+             }
+@@ -97,6 +98,17 @@ namespace Plugin {
+             }
+ 
+         private:
++            void TempDirectoryCheck()
++            {
++                auto journalPath = _path + "-journal";
++                Core::Directory journal(journalPath.c_str());
++                if (journal.Exists()) {
++                    if (Core::File(_path).Size() == 0) { // No db
++                        journal.Destroy(); // Clear
++                    }
++                    Core::File(journalPath).Destroy(); // Destroy if empty
++                }
++            }
+             void IntegrityCheck()
+             {
+                 Core::File file(_path);
+-- 
+2.43.0
+


### PR DESCRIPTION
Reason for change: Temporary -journal folder created by sqlite blocks it from creating a new database after reset. Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>