### PR TITLE
RDKEMW-2941 : Release 1.0.0 for RDKNativeScript components from rdkce…

### DIFF
--- a/recipes-graphics/rdknativescript/rdknativescript_git.bb
+++ b/recipes-graphics/rdknativescript/rdknativescript_git.bb
@@ -15,8 +15,10 @@ S = "${WORKDIR}/git"
 PV ?= "2.0.0"
 PR ?= "r1"
 
-SRC_URI = "${CMF_GITHUB_ROOT}/rdkNativeScript;protocol=${CMF_GITHUB_PROTOCOL};branch=develop"
-SRCREV = "fa08198dbf27755b8d3940dd2069c46ed832cf55"
+SRC_URI = "${CMF_GITHUB_ROOT}/rdkNativeScript;${CMF_GITHUB_SRC_URI_SUFFIX}"
+
+#Release 1.0.0
+SRCREV = "55d66dfa5f636e408c18367ade1804a1595fba68"
 
 OECMAKE_GENERATOR = "Ninja"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
…ntral

Reason for change: Updating the release tag in meta layers.
Test Procedure: build and playback should be successful.
Risks: low
Priority: P2