### PR TITLE
RDK-56155: Bump rdkservices-apis to 1.3.0

### DIFF
--- a/recipes-extended/wpe-framework/rdkservices-apis_1.0.bb
+++ b/recipes-extended/wpe-framework/rdkservices-apis_1.0.bb
@@ -12,8 +12,8 @@ DEPENDS = "wpeframework wpeframework-tools-native"
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name=entservices-apis"
 SRC_URI += "file://RDKEMW-1007.patch"
 
-# Tag 1.2.8
-SRCREV_entservices-apis = "49e58dcb96a1ac718bc8482dbcc1d9afcbbc8c4b"
+# Tag 1.3.0
+SRCREV_entservices-apis = "7f362ef63a9618d6250f13a2ea06866acb2c96c6"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: Bump rdkservices-apis to 1.3.0
Risk: Medium
Priority: P1

Change-Id: Icfe2f5fe253778ac045ad5346554143722ea4796