### PR TITLE
RDKEMW-3192 : Pandora does not resume playback

### DIFF
--- a/recipes-extended/wpe-webkit/files/2.38.8/1423-revert.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/1423-revert.patch
@@ -1,0 +1,111 @@
+From 78ce372adae0cf7f80730fe7432a03b12ee8f80a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Thu, 13 Feb 2025 18:18:49 +0100
+Subject: [PATCH] Unreviewed, reverting 287274@main (71a7e0a)
+ https://bugs.webkit.org/show_bug.cgi?id=285568 rdar://142517488
+
+Broke duolingo, calling play() during a seek() is allowed by the spec. And the play event should be fired even if the seek hasn't completed.
+
+Reverted change:
+
+    [Media] Avoid play() call during seek flow before the finishSeek()
+    https://bugs.webkit.org/show_bug.cgi?id=283172
+    287274@main (71a7e0a)
+
+Canonical link: https://commits.webkit.org/288588@main
+
+---
+
+Revert "[Media] Avoid play() call during seek flow before the finishSeek()"
+
+This reverts commit 6e84da2d0ec3cee5a8b20b07018c2dfcf776c7c8.
+
+See upstream revert: https://bugs.webkit.org/show_bug.cgi?id=285568
+See downstream discussion: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1423
+---
+ Source/WebCore/html/HTMLMediaElement.cpp | 27 +++---------------------
+ Source/WebCore/html/HTMLMediaElement.h   |  2 --
+ 2 files changed, 3 insertions(+), 26 deletions(-)
+
+diff --git a/Source/WebCore/html/HTMLMediaElement.cpp b/Source/WebCore/html/HTMLMediaElement.cpp
+index d309d96e0627b..d5f88dfb47ced 100644
+--- a/Source/WebCore/html/HTMLMediaElement.cpp
++++ b/Source/WebCore/html/HTMLMediaElement.cpp
+@@ -3212,10 +3212,6 @@ void HTMLMediaElement::seekWithTolerance(const MediaTime& inTime, const MediaTim
+     refreshCachedTime();
+     MediaTime now = currentMediaTime();
+ 
+-    // Needed to detect a special case in updatePlayState().
+-    if (now >= durationMediaTime())
+-        m_seekAfterPlaybackEnded = true;
+-
+     // 3 - If the element's seeking IDL attribute is true, then another instance of this algorithm is
+     // already running. Abort that other instance of the algorithm without waiting for the step that
+     // it is running to complete.
+@@ -3387,8 +3383,6 @@ void HTMLMediaElement::finishSeek()
+ #endif
+     if (wasPlayingBeforeSeeking)
+         playInternal();
+-
+-    m_seekAfterPlaybackEnded = false;
+ }
+ 
+ HTMLMediaElement::ReadyState HTMLMediaElement::readyState() const
+@@ -3810,10 +3804,8 @@ void HTMLMediaElement::playInternal()
+     if (!m_player || m_networkState == NETWORK_EMPTY)
+         selectMediaResource();
+ 
+-    if (endedPlayback()) {
+-        m_seekAfterPlaybackEnded = true;
++    if (endedPlayback())
+         seekInternal(MediaTime::zeroTime());
+-    }
+ 
+     if (m_mediaController)
+         m_mediaController->bringElementUpToSpeed(*this);
+@@ -5776,17 +5768,7 @@ void HTMLMediaElement::updatePlayState()
+     if (shouldBePlaying) {
+         invalidateCachedTime();
+ 
+-        // Play is always allowed, except when seeking (to avoid unpausing the video by mistake until the
+-        // target time is reached). However, there are some exceptional situations when we allow playback
+-        // during seek. This is because GStreamer-based implementation have a design limitation that doesn't
+-        // allow initial seeks (seeking before going to playing state), and these exceptions make things
+-        // work for those platforms.
+-        bool isLooping = loop() && m_lastSeekTime == MediaTime::zeroTime();
+-        bool playExceptionsWhenSeeking = m_seeking && (m_firstTimePlaying
+-            || isLooping || m_isResumingPlayback || m_seekAfterPlaybackEnded);
+-        bool allowPlay = !m_seeking || playExceptionsWhenSeeking;
+-
+-        if (playerPaused && allowPlay) {
++        if (playerPaused) {
+             mediaSession().clientWillBeginPlayback();
+ 
+             // Set rate, muted and volume before calling play in case they were set before the media engine was set up.
+@@ -8131,11 +8113,8 @@ void HTMLMediaElement::resumeAutoplaying()
+ void HTMLMediaElement::mayResumePlayback(bool shouldResume)
+ {
+     ALWAYS_LOG(LOGIDENTIFIER, "paused = ", paused());
+-    if (paused() && shouldResume) {
+-        m_isResumingPlayback = true;
++    if (paused() && shouldResume)
+         play();
+-        m_isResumingPlayback = false;
+-    }
+ }
+ 
+ String HTMLMediaElement::mediaSessionTitle() const
+diff --git a/Source/WebCore/html/HTMLMediaElement.h b/Source/WebCore/html/HTMLMediaElement.h
+index 70eb082e5944a..219c6ef3e6823 100644
+--- a/Source/WebCore/html/HTMLMediaElement.h
++++ b/Source/WebCore/html/HTMLMediaElement.h
+@@ -1162,8 +1162,6 @@ class HTMLMediaElement
+     bool m_shouldAudioPlaybackRequireUserGesture : 1;
+     bool m_shouldVideoPlaybackRequireUserGesture : 1;
+     bool m_volumeLocked : 1;
+-    bool m_isResumingPlayback : 1 { false };
+-    bool m_seekAfterPlaybackEnded : 1 { false };
+ 
+     AutoplayEventPlaybackState m_autoplayEventPlaybackState { AutoplayEventPlaybackState::None };
+
+

--- a/recipes-extended/wpe-webkit/files/2.38.8/comcast-LLAMA-16805-Include-HW-secure-decrypt-decode-in-robu.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/comcast-LLAMA-16805-Include-HW-secure-decrypt-decode-in-robu.patch
@@ -1,0 +1,29 @@
+From 9683c90611a1421d846d483479002d2b35ba28b7 Mon Sep 17 00:00:00 2001
+From: Filipe Norte <filipe_norte@comcast.com>
+Date: Thu, 20 Feb 2025 10:17:11 +0000
+Subject: [PATCH] LLAMA-16805: Include HW secure decrypt/decode in robustness
+
+Widevine uses 3 robustness levels with increasing security.
+Highest security level (L1) corresponding to HW decryption
+and decoding while supported, was not being indicated to
+upper layers as such.
+---
+ Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+index 903f78a4ab6d..a23ba3be23e8 100644
+--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
++++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+@@ -174,7 +174,7 @@ bool CDMPrivateThunder::supportsConfiguration(const CDMKeySystemConfiguration& c
+ 
+ Vector<AtomString> CDMPrivateThunder::supportedRobustnesses() const
+ {
+-    return { emptyAtom(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s };
++    return { emptyAtom(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s, "HW_SECURE_DECODE"_s, "HW_SECURE_CRYPTO"_s, "HW_SECURE_ALL"_s };
+ }
+ 
+ CDMRequirement CDMPrivateThunder::distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const
+-- 
+2.43.0
+

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.38.8.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.38.8.bb
@@ -3,7 +3,7 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r3"
+PR  = "r5"
 
 # Temporary build fix
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
@@ -23,6 +23,9 @@ SRC_URI += "file://2.38.7/1410.patch"
 
 # Drop after issue is addressed and a corresponding PR is merged
 SRC_URI += "file://2.38.8/1456-RDKTV-35082-Workaround-premature-finishSeek.patch"
+
+# Drop after tip of branch has been revised
+SRC_URI += "file://2.38.8/1423-revert.patch"
 
 # Drop after libwpe upgrade
 SRC_URI += "file://2.38.8/RDK-54304-Fix-build-with-an-older-libpwe.patch"
@@ -68,6 +71,7 @@ SRC_URI += "file://2.38.5/comcast-RDK-48799-disable-service-worker-by-default.pa
 SRC_URI += "file://2.38.8/comcast-DELIA-57933-Increase-minor-version-or-WPE-lib.patch"
 SRC_URI += "file://2.38.8/comcast-LLAMA-15112-sleep-150-microsecs-instead-of-s.patch"
 SRC_URI += "file://2.38.8/comcast-DELIA-67128-GCHeap-snapshot.patch"
+SRC_URI += "file://2.38.8/comcast-LLAMA-16805-Include-HW-secure-decrypt-decode-in-robu.patch"
 
 PACKAGECONFIG[wpeqtapi]          = "-DENABLE_WPE_QT_API=ON,-DENABLE_WPE_QT_API=OFF"
 PACKAGECONFIG[westeros]          = "-DUSE_WPEWEBKIT_PLATFORM_WESTEROS=ON -DUSE_GSTREAMER_HOLEPUNCH=ON -DUSE_EXTERNAL_HOLEPUNCH=ON -DUSE_WESTEROS_SINK=ON,,westeros virtual/vendor-westeros-sink"


### PR DESCRIPTION
Reason for change: Revert for change brought in webkit downstream calling play() during a seek() is allowed by the spec. And the play event should be fired even if the seek hasn't completed. Test Procedure: Check ticket
Risks: NA