### PR TITLE
RDKEMW-2148 - GetIPSettings() method returns failure when ipversion is empty

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.12.0"
+PV = "0.13.0"
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=develop"
+SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Mar 31, 2025
-SRCREV = "f432890f82e4631321f211550247447b0253a3a1"
+# Apr 07, 2025
+SRCREV = "49c3bcb4b4bdddd0edd7cb6773f01807bee3434f"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework rdkservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Updated the networkmanager plugin version to 0.13.0
Test Procedure: NA
Risks: low
Priority: P2
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>