### PR TITLE
RDKEMW-2233: Updated getBootType and SetMigrationStatus method

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.9
-SRCREV = "bb654292e00a442292dd9a6d7eb61e75de0d2f9e"
+# Release version - 1.1.0
+SRCREV = "9499c1925963461402ec1d510dc5c4561b0d2320"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Methods for find bootType and MigrationStatus
Test Procedure: None
Priority: P1
Risks: Medium
Signed-off-by: Faizal Hasan.Z <faizalhasan_zahirhussain@comcast.com>