### PR TITLE
RDKEMW-3252 L2 - Fixing the Telemetry test

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -18,7 +18,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
 
 # Release version - 1.1.10
 # Telemetry check
-SRCREV = "aa57e61ffc426d61be1e4201919e934acaf5cfc2"
+SRCREV = "77f8adcf05eb392fcab138c11ff91dedbafb127d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -17,7 +17,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
           "
 
 # Release version - 1.1.10
-SRCREV = "4c83512853beb63fa0c2bce96e8a8f89a200ad8e"
+# Telemetry check
+SRCREV = "97341cbb369c1b59775bfdbf08fc5508b13624b4"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -18,7 +18,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
 
 # Release version - 1.1.10
 # Telemetry check
-SRCREV = "77f8adcf05eb392fcab138c11ff91dedbafb127d"
+SRCREV = "11a2263e1f1d910586b2f95ceecfb4bd51f85291"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -18,7 +18,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
 
 # Release version - 1.1.10
 # Telemetry check
-SRCREV = "97341cbb369c1b59775bfdbf08fc5508b13624b4"
+SRCREV = "aa57e61ffc426d61be1e4201919e934acaf5cfc2"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: Remove IARMBus libraries from link libraries.
Test Procedure: Run L2Test to verify
Risks: Medium