### PR TITLE
Rebase

### DIFF
--- a/recipes-extended/thunderstartupservices/thunderstartupservices.bb
+++ b/recipes-extended/thunderstartupservices/thunderstartupservices.bb
@@ -46,6 +46,7 @@ THUNDER_STARTUP_SERVICES:append = "\
     wpeframework-usbmassstorage.service \
     wpeframework-firmwareupdate.service \
     wpeframework-powermanager.service \
+    wpeframework-networkmanager.service \
     "
 
 do_install() {


### PR DESCRIPTION
RDKEMW-3311 - NetworkManager Thunder Plugin - Systemd Service cleanup (#118)

Reason for change: Moved the wpeframework-networkmanager.service to thunder-startup-services
Test Procedure: check the command "systemctl status NetworkManager"
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR<gururaja_erodesriranganramlingham@comcast.com>