### PR TITLE
RDK-57093: PowerManager plugin interface change

### DIFF
--- a/recipes-extended/entservices/entservices-casting.bb
+++ b/recipes-extended/entservices/entservices-casting.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices Casting plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=be469927b9722d71bc41ecd5e71fe35f"
 
-PV ?= "1.0.5"
+PV ?= "1.0.6"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-casting;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.5
-SRCREV = "39911976d1509bfde2dfb09167bdc87d0dae5943"
+# Release version - 1.0.6
+SRCREV = "ceb1e28b7d0b67e67c94e19f137df77766acb581"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices deviceanddisplay plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dc6e390ad71aef79d0c2caf3cde03a19"
 
-PV ?= "1.0.8"
+PV ?= "1.1.2"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.1.1
-SRCREV = "a4249900d50b655d12b92a442749f8295bd8f72a"
+# Release version - 1.1.2
+SRCREV = "c7bc228770c565d782271e9f9a9ce735fb0ac819"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices Infra plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9adde9d5cb6e9c095d3e3abf0e9500f1"
 
-PV ?= "1.1.10"
+PV ?= "1.1.11"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -16,8 +16,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDK-41681-PR4013.patch \
           "
 
-# Release version - 1.1.10
-SRCREV = "4c83512853beb63fa0c2bce96e8a8f89a200ad8e"
+# Release version - 1.1.11
+SRCREV = "70a5cbf3d8e28be96fde8a938f1ea2fa92366a25"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices inputoutput plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dc6e390ad71aef79d0c2caf3cde03a19"
 
-PV ?= "1.0.6"
+PV ?= "1.0.8"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.6
-SRCREV = "f46b084ed21e61d89e20868eacdea4ba8198266d"
+# Release version - 1.0.8
+SRCREV = "fe37f210ddbf3e698fccc454fd7593e7fb6e4a9d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-peripherals.bb
+++ b/recipes-extended/entservices/entservices-peripherals.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices peripherals plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7e2eceb64cc374eafafd7e1a4e763f63"
 
-PV ?= "1.0.2"
+PV ?= "1.0.3"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-peripherals;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.2
-SRCREV = "2b70145a578074f54c2bfd78764b89a8b85121de"
+# Release version - 1.0.3
+SRCREV = "5e635e0a476e7e363ae93e7cde50dd0bee6b24be"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/wpe-framework/rdkservices-apis_1.0.bb
+++ b/recipes-extended/wpe-framework/rdkservices-apis_1.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "rdkservices-apis"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d8927f3331d2b3e321b7dd1925166d25"
-PV ?= "1.2.8"
+PV ?= "1.3.3"
 PR ?= "r0"
 
 inherit python3native cmake pkgconfig
@@ -12,8 +12,8 @@ DEPENDS = "wpeframework wpeframework-tools-native"
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name=entservices-apis"
 SRC_URI += "file://RDKEMW-1007.patch"
 
-# Tag 1.3.2
-SRCREV_entservices-apis = "d1e54eeeeb0b1d6f7af0949c7a1fa4e3804b31a0"
+# Tag 1.3.3
+SRCREV_entservices-apis = "50fc555c94178377bb6eb355825b00ea272c1c17"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0001-PowerManagerClient-library-implementation.patch
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0001-PowerManagerClient-library-implementation.patch
@@ -1,4 +1,4 @@
-From 068bef79bb4597136b9c1c0a7270ee14474c85d1 Mon Sep 17 00:00:00 2001
+From 4cd3b5f4d2c55a004dc3202baea93b81709ea1d8 Mon Sep 17 00:00:00 2001
 From: Shrinivas Kamath <skamath@synamedia.com>
 Date: Wed, 22 Jan 2025 15:52:21 +0000
 Subject: [PATCH] PowerController (PowerManager plugin client) implementation
@@ -13,6 +13,7 @@ interface changes for enhanced instance management and add operational state tra
   `Dispose` (older API now removed)
 - Introduced isOperational and it's state change callback
 - PowerModePreChange & Thunder restart handling
+- Adapt to IPowerManager interface changes
 
 %% original patch: 0001-PowerManagerClient-library-implementation.patch
 ---
@@ -227,7 +228,7 @@ index 0000000..c9c1321
 +#endif
 diff --git a/Source/powercontroller/power_controller.cpp b/Source/powercontroller/power_controller.cpp
 new file mode 100644
-index 0000000..93f10cf
+index 0000000..eb23c38
 --- /dev/null
 +++ b/Source/powercontroller/power_controller.cpp
 @@ -0,0 +1,1834 @@
@@ -945,27 +946,27 @@ index 0000000..93f10cf
 +        Notification(Notification&&) = delete; // Delete move constructor
 +        Notification& operator=(Notification&&) = delete; // Delete move assignment operator
 +
-+        virtual void OnPowerModeChanged(const PowerState& currentState, const PowerState& newState) override
++        virtual void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
 +        {
 +            _parent.NotifyPowerModeChanged(currentState, newState);
 +        }
 +
-+        virtual void OnPowerModePreChange(const PowerState& currentState, const PowerState& newState, const int transactionId, const int stateChangeAfter) override
++        virtual void OnPowerModePreChange(const PowerState currentState, const PowerState newState, const int transactionId, const int stateChangeAfter) override
 +        {
 +            _parent.NotifyPowerModePreChange(currentState, newState, transactionId, stateChangeAfter);
 +        }
 +
-+        virtual void OnDeepSleepTimeout(const int& wakeupTimeout) override
++        virtual void OnDeepSleepTimeout(const int wakeupTimeout) override
 +        {
 +            _parent.NotifyDeepSleepTimeout(wakeupTimeout);
 +        }
 +
-+        virtual void OnNetworkStandbyModeChanged(const bool& enabled) override
++        virtual void OnNetworkStandbyModeChanged(const bool enabled) override
 +        {
 +            _parent.NotifyNetworkStandbyModeChanged(enabled);
 +        }
 +
-+        virtual void OnThermalModeChanged(const ThermalTemperature& currentThermalLevel, const ThermalTemperature& newThermalLevel, const float& currentTemperature) override
++        virtual void OnThermalModeChanged(const ThermalTemperature currentThermalLevel, const ThermalTemperature newThermalLevel, const float currentTemperature) override
 +        {
 +            _parent.NotifyThermalModeChanged(currentThermalLevel, newThermalLevel, currentTemperature);
 +        }
@@ -1552,7 +1553,7 @@ index 0000000..93f10cf
 +        return result;
 +    }
 +
-+    void NotifyPowerModeChanged(const PowerState& currentState, const PowerState& newState)
++    void NotifyPowerModeChanged(const PowerState currentState, const PowerState newState)
 +    {
 +        PowerController_PowerState_t currentState_ = convert(currentState);
 +        PowerController_PowerState_t newState_ = convert(newState);
@@ -1565,7 +1566,7 @@ index 0000000..93f10cf
 +        _callbackLock.Unlock();
 +    }
 +
-+    void NotifyPowerModePreChange(const PowerState& currentState, const PowerState& newState, const int transactionId, const int stateChangeAfter)
++    void NotifyPowerModePreChange(const PowerState currentState, const PowerState newState, const int transactionId, const int stateChangeAfter)
 +    {
 +        PowerController_PowerState_t currentState_ = convert(currentState);
 +        PowerController_PowerState_t newState_ = convert(newState);
@@ -1578,7 +1579,7 @@ index 0000000..93f10cf
 +        _callbackLock.Unlock();
 +    }
 +
-+    void NotifyDeepSleepTimeout(const int& wakeupTimeout)
++    void NotifyDeepSleepTimeout(const int wakeupTimeout)
 +    {
 +        _callbackLock.Lock();
 +
@@ -1589,7 +1590,7 @@ index 0000000..93f10cf
 +        _callbackLock.Unlock();
 +    }
 +
-+    void NotifyNetworkStandbyModeChanged(const bool& enabled)
++    void NotifyNetworkStandbyModeChanged(const bool enabled)
 +    {
 +        _callbackLock.Lock();
 +
@@ -1600,7 +1601,7 @@ index 0000000..93f10cf
 +        _callbackLock.Unlock();
 +    }
 +
-+    void NotifyThermalModeChanged(const ThermalTemperature& currentThermalLevel, const ThermalTemperature& newThermalLevel, const float& currentTemperature)
++    void NotifyThermalModeChanged(const ThermalTemperature currentThermalLevel, const ThermalTemperature newThermalLevel, const float currentTemperature)
 +    {
 +        PowerController_ThermalTemperature_t currentThermalLevel_ = convert(currentThermalLevel);
 +        PowerController_ThermalTemperature_t newThermalLevel_ = convert(newThermalLevel);


### PR DESCRIPTION
RDK-57093: PowerManager plugin interface change

Reason for change: Interface API arguments not to be passed by reference if
it's a primitive data type.
Test Procedure: SetPowerState & QueryPowerState sanity
Risks: LOW
Signed-off-by : bp-skamat286 [skamath@synamedia.co](mailto:skamath@synamedia.co)