### PR TITLE
RDKEMW-3359:HdmiCecSink RDK-V to RDK-E sync changes (#123)

### DIFF
--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.0.6
-SRCREV = "f46b084ed21e61d89e20868eacdea4ba8198266d"
+SRCREV = "d6e5a4d9ad4200452db1140d2fbe0342c4a43345"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
* RDKTV-32538: The HDMI volume Icon is not smooth

Reason for change: Optimize Audio Status Request on Volume Key Press
Test Procedure: refer the ticket
Risks: None
Signed-off-by: Neethu A S neethu.arambilsunny@sky.uk

* RDKEMW-3359: HdmiCecSink sync