### PR TITLE
RDKEMW-3169 : Fix VREX TTS2.0 VG not working in RDKE

### DIFF
--- a/recipes-extended/entservices/entservices-mediaanddrm.bb
+++ b/recipes-extended/entservices/entservices-mediaanddrm.bb
@@ -24,8 +24,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-mediaanddrm;${CMF_GITHUB_SRC_URI_SUFFI
           "
 SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'rdk_svp', 'file://0001-LLAMA-3066-10405-increase-OCDM-process-priority.patch', "", d)}"
 
-# Release version - 1.1.0
-SRCREV = "498c4505a03dd537b3030bb82aa25bfdeab19816"
+# Release version - 1.1.1
+SRCREV = "529ff8794b10a83dc813f3d59f3f4a1ddcedcc2e"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: Bring fix to R37
Test Procedure: Mentioned in ticket
Risks: Low