### PR TITLE
RDKEMW-2572 [RDKE] DeviceInfo.make coming as element for Sharp

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
           "
 
 # Release version - 1.1.4
-SRCREV = "e4b662c04c878ad563dba222dc3105d2eaa54c92"
+SRCREV = "3ac379fe3090ad3671f58d61673c3c6c215a81b7"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: read make from MFR first and if not available fall back to device.properties.
Test Procedure: None
Risks: None
Signed-off-by: ramkumar_prabaharan ramkumar_prabaharan@comcast.com