### PR TITLE
RDKEMW-3682, RDKEMW-3086, RDKEMW-3414  NetworkManager Plugin Release …

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.14.0"
+PV = "0.15.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Apr 21, 2025
-SRCREV = "d8b40a1adab34f817a835345d74d1e26216425fa"
+# Apr 24, 2025
+SRCREV = "a5b1f0769ea80ee7a345c8f3db1b1d4f8d16658d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework rdkservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
…- 0.15.0 (#249)

Reason for change: Upgrade to new release - 0.15.0 with following Bug fixes

* Memory leak is observed with Network Manager plugin
* Unable to Reconnect to WiFi using WPS -Screen stuck at Searching page
* Enable CLI Tool in NetworkManager-Plugin: Add Compile-Time Option for gdbus & resolve compilation error

Test Procedure: Please referred the ticket
Risks: Medium
Signed-off-by: Thamim Razith Abbas Ali <ThamimRazith_AbbasAli@comcast.com>