### PR TITLE
RDKEMW-3914: NetworkManager Plugin Release - 0.16.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -19,7 +19,7 @@ S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# May 24, 2025
+# May 02, 2025
 SRCREV = "410b5d5411f7e6deb2fde0a5d3e9f0bcb12d8408"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"

--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.15.0"
+PV = "0.16.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Apr 24, 2025
-SRCREV = "a5b1f0769ea80ee7a345c8f3db1b1d4f8d16658d"
+# May 24, 2025
+SRCREV = "410b5d5411f7e6deb2fde0a5d3e9f0bcb12d8408"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.16.0 with following Bug fixes
 * Fixed the deregistration of Security Agent upon one successful WPS Connect.
 * JSONRPC response for Ping in the legacy plugin is addressed