### PR TITLE
RDKEMW-2572 [RDKE] DeviceInfo.make coming as element for Sharp

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.1.6
-SRCREV = "5722c9237de2d30e0208d786204c37f1140139c3"
+# Release version - 1.1.7
+SRCREV = "54b8a14dd82b52974311897b8781f09a330cbd35"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: read make from MFR first and if not available fall back to device.properties.
Test Procedure: None
Risks: None
Signed-off-by: ramkumar_prabaharan ramkumar_prabaharan@comcast.com