### PR TITLE
RDKEMW-4169 : /opt/secure unmounts early

### DIFF
--- a/recipes-extended/ctrlm/files/ctrlm-main.service
+++ b/recipes-extended/ctrlm/files/ctrlm-main.service
@@ -3,6 +3,7 @@ Description=Control Manager Main Service
 After=iarmbusd.service securemount.service tr69hostif.service dsmgr.service
 Requires=iarmbusd.service dsmgr.service
 Wants=tr69hostif.service
+RequiresMountsFor=/opt/secure
 
 [Service]
 Type=notify

--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=wpeframework
 Wants=network-online.target local-fs.target
-After= network-online.target local-fs.target
+After= network-online.target local-fs.target securemount.service
+RequiresMountsFor=/opt/secure
 
 [Service]
 Type=notify


### PR DESCRIPTION
Reason for change: wpeframework/ctrlm
should stop before secure folder to prevent
fs corruption and umount failure.
Test Procedure: Check system.log.
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>

Change-Id: I2f1c011628891938464da496e25e73e3699070f0