### PR TITLE
RDKEMW-4148: Move networkmanager user wifi data to /opt/secure

### DIFF
--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -263,6 +263,8 @@ do_install() {
 	install -d ${D}${sysconfdir}/NetworkManager/conf.d
 	install -d ${D}${sysconfdir}/NetworkManager/dispatcher.d
 	install -d ${D}${sysconfdir}/NetworkManager/dispatcher.d/pre-down.d
+        install -d ${D}${systemd_unitdir}/system/NetworkManager.service.d
+        install -m 0755 ${S}/systemd_units/NetworkManager_ecfs.conf ${D}${systemd_unitdir}/system/NetworkManager.service.d
         install -d ${D}/opt
         install -d ${D}/opt/secure
         install -d ${D}/opt/secure/NetworkManager

--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -265,9 +265,6 @@ do_install() {
 	install -d ${D}${sysconfdir}/NetworkManager/dispatcher.d/pre-down.d
         install -d ${D}${systemd_unitdir}/system/NetworkManager.service.d
         install -m 0755 ${S}/systemd_units/NetworkManager_ecfs.conf ${D}${systemd_unitdir}/system/NetworkManager.service.d
-        install -d ${D}/opt
-        install -d ${D}/opt/secure
-        install -d ${D}/opt/secure/NetworkManager
 	install -m 0755 ${S}/lib/rdk/NM_Dispatcher.sh ${D}${sysconfdir}/NetworkManager/dispatcher.d
 	install -m 0755 ${S}/lib/rdk/NM_preDown.sh ${D}${sysconfdir}/NetworkManager/dispatcher.d/pre-down.d
 	install -m 0755 ${S}/etc/10-unmanaged-devices ${D}${sysconfdir}/NetworkManager/conf.d/10-unmanaged-devices.conf

--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -263,6 +263,9 @@ do_install() {
 	install -d ${D}${sysconfdir}/NetworkManager/conf.d
 	install -d ${D}${sysconfdir}/NetworkManager/dispatcher.d
 	install -d ${D}${sysconfdir}/NetworkManager/dispatcher.d/pre-down.d
+        install -d ${D}/opt
+        install -d ${D}/opt/secure
+        install -d ${D}/opt/secure/NetworkManager
 	install -m 0755 ${S}/lib/rdk/NM_Dispatcher.sh ${D}${sysconfdir}/NetworkManager/dispatcher.d
 	install -m 0755 ${S}/lib/rdk/NM_preDown.sh ${D}${sysconfdir}/NetworkManager/dispatcher.d/pre-down.d
 	install -m 0755 ${S}/etc/10-unmanaged-devices ${D}${sysconfdir}/NetworkManager/conf.d/10-unmanaged-devices.conf


### PR DESCRIPTION
Reason for change: Move user data to secure partition
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)