### PR TITLE
RDKEMW-4076:Sync DELIA-67278 changes to RDK-E

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -20,6 +20,7 @@ ExecStart=-/usr/bin/WPEFramework -b
 # Thunder aka WPEFramework process is restarted. Please note if PIDFile name is changed
 # it will need corresponding code change in ThunderClientLibraries (power_controller) too.
 ExecStartPost=-/bin/sh -c '/bin/echo ${MAINPID} > /tmp/wpeframework.pid'
+ExecStartPost=/bin/touch /tmp/wpeframeworkstarted
 ExecStop=/usr/bin/killall -9 WPEFramework
 ExecStopPost=/usr/bin/killall -9 WPEProcess
 KillSignal=SIGKILL


### PR DESCRIPTION
Reason for change: OCDM service is not active after restart of the WPEFramework service 
Test Procedure: Check status of OCDM plugin and service it should in active state 
Risks: Low
Signed-off-by:AkshayKumar_Gampa <AkshayKumar_Gampa@comcast.com>