### PR TITLE
RDKEMW-2738 : Make recipe updates to build AppManager

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -64,6 +64,9 @@ PACKAGECONFIG ?= " monitor \
     rdknativescript \
     javascriptcore \
     packagemanager \
+    lifecyclemanager \
+    storagemanager \
+    appmanager \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC-sec',              'ocicontainersec', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'rdkshell',             'rdkshell', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'rdkshell enable_rialto', 'rdkshellrialto', '', d)} \
@@ -121,6 +124,9 @@ PACKAGECONFIG[rustadapter]          = "-DPLUGIN_RUSTADAPTER=ON,,,"
 PACKAGECONFIG[runtimemanager]       = "-DPLUGIN_RUNTIME_MANAGER=ON,-DPLUGIN_RUNTIME_MANAGER=OFF,entservices-apis,entservices-apis"
 PACKAGECONFIG[rdknativescript]      = "-DPLUGIN_NATIVEJS=ON,-DPLUGIN_NATIVEJS=OFF,rdknativescript,libuv"
 PACKAGECONFIG[packagemanager]       = "-DPLUGIN_PACKAGE_MANAGER=ON -DLIB_PACKAGE=ON -DSYSROOT_PATH=${STAGING_DIR_TARGET},-DPLUGIN_PACKAGE_MANAGER=OFF -DLIB_PACKAGE=OFF,curl virtual/libpackage,curl virtual/libpackage"
+PACKAGECONFIG[lifecyclemanager]     = "-DPLUGIN_LIFECYCLE_MANAGER=ON,-DPLUGIN_LIFECYCLE_MANAGER=OFF,websocketpp entservices-apis,entservices-apis"
+PACKAGECONFIG[storagemanager]       = "-DPLUGIN_STORAGE_MANAGER=ON,-DPLUGIN_STORAGE_MANAGER=OFF,entservices-apis,entservices-apis"
+PACKAGECONFIG[appmanager]           = "-DPLUGIN_APPMANAGER=ON,-DPLUGIN_APPMANAGER=OFF,entservices-apis,entservices-apis"
 
 # ----------------------------------------------------------------------------
 

--- a/recipes-extended/thunderstartupservices/thunderstartupservices.bb
+++ b/recipes-extended/thunderstartupservices/thunderstartupservices.bb
@@ -26,7 +26,6 @@ THUNDER_STARTUP_SERVICES:append = "\
     wpeframework-monitor.service \
     wpeframework-network.service \
     wpeframework-ocdm.service \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT',' wpeframework-lisa.service wpeframework-ocicontainer.service', '', d)} \
     wpeframework-persistentstore.service \
     wpeframework-playerinfo.service \
     wpeframework-sharedstorage.service \
@@ -47,6 +46,14 @@ THUNDER_STARTUP_SERVICES:append = "\
     wpeframework-firmwareupdate.service \
     wpeframework-powermanager.service \
     wpeframework-networkmanager.service \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT',' wpeframework-lisa.service', '', d)} \
+    wpeframework-ocicontainer.service \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'rdkwindowmanager',' wpeframework-rdkwindowmanager.service', '', d)} \
+    wpeframework-lifecyclemanager.service \
+    wpeframework-runtimemanager.service \
+    wpeframework-storagemanager.service \
+    wpeframework-packagemanager.service \
+    wpeframework-appmanager.service \
     "
 
 do_install() {


### PR DESCRIPTION
Reason for change : Recipe changes for lifecyclemanager, storagemanager and appmanager
  This includes changes for RDKEMW-2734, RDKEMW-2735, RDKEMW-2736 and RDKEMW-2737.
Test Procedure: Plugins are not activated by default. They are only activated when done manually. Risks: Medium
Priority: P1
Signed-off-by: Abhay Kant bp-akant305@cable.comcast.com