### PR TITLE
RDKEMW-4393 : [AML-VA-DEVICES]Setting lower resolutions changes the screen size instead of screen quality.

### DIFF
--- a/recipes-graphics/rdkshell/rdkshell_git.bb
+++ b/recipes-graphics/rdkshell/rdkshell_git.bb
@@ -23,6 +23,8 @@ SRCREV ?= "a0a88b812d39ee57b15b48f00488c4d9ba737f14"
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append = " file://shared_ptr_fix_kirkstone.patch"
 
+EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'enable_rdkshell_force_1080', '-DRDKSHELL_BUILD_FORCE_1080=ON', '', d)}"
+
 do_install() {
     install -d ${D}/home/root
     install -m 0755 ${B}/rdkshell ${D}/home/root/


### PR DESCRIPTION
**Reason for change:** As per analysis of this issue, the issue is reproduced only in the RDKE AML VA device builds; it is not observed in AML-VA RDKV builds. In RDKV build, in the soc specific meta layer named as meta-rdk-bsp-amlogic is have the bbappends for the rdkshell recipe file. https://code.rdkcentral.com/r/plugins/gitiles/collaboration/soc/amlogic/yocto_oe/layers/meta-rdk-bsp-amlogic/+/refs/heads/rdk-next/recipes-graphics/rdkshell/

In the lib32-rdkshell component source, the RDKSHELL_BUILD_FORCE_1080 OECMAKE flag is needed to enable, and this flag is used to enable the RDKSHELL_ENABLE_FORCE_1080 compilation CFLAG from the cmake file. Patches updates are missed in the RDKE build because patches are present in the vendor layer meta-rdk-bsp-amlogic. We enabled this needed OECMAKE flag in RDKE middleware and validated the issue. The issue is not reproduced in the RDKE image. We have enabled the OECMAKE flag by using the DISTRO checks.

This patch changes that came as part of the BSP release of AML in RDKV. So, we need these changes for RDKM-RDKE AML VA devices.
**Test Procedure:** Build verification and basic playback validation. 
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com