### PR TITLE
RDKEMW-4175 : WiFi Power Switch toggling On/Off support

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -17,10 +17,10 @@ PR = "r0"
 PV = "0.18.0"
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
+SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=develop"
 
-# May 21, 2025
-SRCREV = "f7344c0481df8e9e083f1653893274a932ab51a3"
+# May 22, 2025
+SRCREV = "b1ba3cf9c0186104e86e4603425ed8f629344358"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change:  for following issues
	- RDKEMW-3859 SetInterfaceState is not working as expected for the wlan0 interface.
	- RDKEMW-4063 [RDKE][Gnome]WiFi is connected on bootup even if WiFi option was disabled before reboot
	- RDKEMW-4106 [RDKEMW][FOXTEL]Device does not automatically reconnect to WiFi SSID after toggling WiFi OFF and ON
	- RDKEMW-4175 WiFi doesn't connect back automatically to previously connected SSID after toggling WiFi On/Off Switch