### PR TITLE
RDKEMW-2871 IFirmwareUpdate.h Interface header not following coding

### DIFF
--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name
 SRC_URI += "file://RDKEMW-1007.patch"
 
 # Tag 1.3.12
-SRCREV_entservices-apis = "a6b37879afa86c84562ddc54a125f0f9b3bfb633"
+SRCREV_entservices-apis = "6d8de3fe98c030933854abda56db3c57c70c8e17"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: Solve the guideline issues on IFirmwareUpdate.h
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com