### PR TITLE
RDKEMW-4220: Fix wpeframework crash on reactivating plugin and power state change

### DIFF
--- a/recipes-extended/entservices/entservices-casting.bb
+++ b/recipes-extended/entservices/entservices-casting.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-casting;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.5
-SRCREV = "39911976d1509bfde2dfb09167bdc87d0dae5943"
+# Release version - 1.0.5-RDK7.1 from support/rdk7-main
+SRCREV = "13b65fbfdde52cf369258fe6ae7c62b9c9c3148d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.9
-SRCREV = "bb654292e00a442292dd9a6d7eb61e75de0d2f9e"
+# Release version - 1.0.9-RDK7.1 from support/rdk7-main
+SRCREV = "393bc6f0eefe91d497737a092ee67fa0a2e56c5c"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -16,10 +16,10 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDK-41681-PR4013.patch \
           "
 
-# Release version - 1.1.10
-SRCREV = "4c83512853beb63fa0c2bce96e8a8f89a200ad8e"
+# Release version - 1.1.10-RDK7.1 from support/rdk7-main
+SRCREV = "183ec6ac9a4492f12e2d6fce42878025ee5f9da9"
 
-PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
+PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"
 DISTRO_FEATURES_CHECK = "wpe_r4_4 wpe_r4"
 EXTRA_OECMAKE += "${@bb.utils.contains_any('DISTRO_FEATURES', '${DISTRO_FEATURES_CHECK}', ' -DUSE_THUNDER_R4=ON', '', d)}"

--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.6
-SRCREV = "f46b084ed21e61d89e20868eacdea4ba8198266d"
+# Release version - 1.0.6-RDK7.1 from support/rdk7-main
+SRCREV = "8aeb187ec11b99523b39dfcf329ddf2b10e72a3f"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-peripherals.bb
+++ b/recipes-extended/entservices/entservices-peripherals.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-peripherals;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.2
-SRCREV = "2b70145a578074f54c2bfd78764b89a8b85121de"
+# Release version - 1.0.2-RDK7.1 from support/rdk7-main
+SRCREV = "02fee0a5d6573921d8636ca269dc387f596d4666"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for Change: Fix wpeframework crash on reactivating plugin and power state change.
Reference:
- https://github.com/rdkcentral/entservices-casting/commit/13b65fbfdde52cf369258fe6ae7c62b9c9c3148d
- https://github.com/rdkcentral/entservices-deviceanddisplay/commit/393bc6f0eefe91d497737a092ee67fa0a2e56c5c
- https://github.com/rdkcentral/entservices-peripherals/commit/02fee0a5d6573921d8636ca269dc387f596d4666
- https://github.com/rdkcentral/entservices-inputoutput/commit/8aeb187ec11b99523b39dfcf329ddf2b10e72a3f
- https://github.com/rdkcentral/entservices-infra/commit/183ec6ac9a4492f12e2d6fce42878025ee5f9da9

Test Procedure: Please see ticket for details.