### PR TITLE
RDKEMW-4615: RDK-E : libloader-app Remove AUTOINC from the PV

### DIFF
--- a/recipes-extended/cobalt/libloader-app_24.lts.stable.bb
+++ b/recipes-extended/cobalt/libloader-app_24.lts.stable.bb
@@ -29,7 +29,7 @@ PR = "r${CR}"
 SRCREV_cobalt = "24.lts.${CR}"
 SRCREV_larboard = "${LARBOARD_SRCREV_24}"
 SRCREV_FORMAT = "cobalt_larboard"
-PV .= "+git${SRCPV}"
+PV = "${SRCREV_cobalt}"
 
 do_fetch[vardeps] += " SRCREV_FORMAT SRCREV_cobalt SRCREV_larboard"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change:
	RDK-E : libloader-app Remove AUTOINC from the PV

Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com> (cherry picked from commit de0f2608dd4fd1fb65eead05d4f94bebd58f5075)