### PR TITLE
RDKEMW-4204: Cleanup and remove pwrmgr references from entservices-ca…

### DIFF
--- a/recipes-extended/entservices/entservices-casting.bb
+++ b/recipes-extended/entservices/entservices-casting.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices Casting plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=be469927b9722d71bc41ecd5e71fe35f"
 
-PV ?= "1.0.9"
+PV ?= "1.0.10"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-casting;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.9
-SRCREV = "22ec1548feb758774d35c9b4c85fa1b7e153423b"
+# Release version - 1.0.10
+SRCREV = "55a48f3686298e85a9b21659462c0f0280304981"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
…sting (#521)

Reason for change: Cleanup and remove pwrmgr references from entservices-casting Test Procedure: build
Risks: Medium
Signed-off-by:gsanto722 grandhi_santoshkumar@comcast.com