### PR TITLE
RDKEMW-3788: Add WhoAmI support to DeviceProvisioning (meta-rdk-video)

### DIFF
--- a/recipes-extended/wpe-framework/entservices-apis/RDKEMW-1007.patch
+++ b/recipes-extended/wpe-framework/entservices-apis/RDKEMW-1007.patch
@@ -56,6 +56,12 @@ diff -uprN a/apis/AuthService/IAuthService.h b/apis/AuthService/IAuthService.h
 +        // @text serviceAccessTokenChanged
 +        // @brief The service access token has changed.
 +        virtual void ServiceAccessTokenChanged() = 0;
++        // @text onPartnerIdChanged
++        // @brief The Partner ID has changed.
++        // @param oldPartnerId old partner ID
++        // @param newPartnerId new partner ID
++        // @param isNew whether this is a new partner ID (not a change)
++        virtual void OnPartnerIdChanged(const string& oldPartnerId, const string& newPartnerId, const bool isNew) = 0;
 +    };
 +
 +    virtual uint32_t Register(IAuthService::INotification* notification /* @in */) = 0;


### PR DESCRIPTION
Reason for change: missing WAI support in RDK-E
Test Procedure: described in the ticket
Implements: code changes in AuthService and DeviceProvisioning
Risks: No
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending