### PR TITLE
RDKEMW-4522: Phone not able to cast screen on alternate connection

### DIFF
--- a/recipes-connectivity/wlan-p2p/files/p2p_udhcpc.script
+++ b/recipes-connectivity/wlan-p2p/files/p2p_udhcpc.script
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# udhcpc script edited by Tim Riker <Tim@Rikers.org>
+
+[ -z "$1" ] && echo "Error: should be called from udhcpc" && exit 1
+
+RESOLV_CONF="/etc/resolv.conf"
+[ -n "$subnet" ] && NETMASK="netmask $subnet"
+
+echo "`date +"%b %d %T.%6N"` : udhcpc : $1,$interface,$ip,$subnet,$broadcast,DNS=$dns,$message" >> /opt/logs/wpa_p2p_supplicant.log
+
+# return 0 if root is mounted on a network filesystem
+root_is_nfs() {
+	sed -n 's/^[^ ]* \([^ ]*\) \([^ ]*\) .*$/\1 \2/p' /proc/mounts |
+	grep -q "^/ \(nfs\|smbfs\|ncp\|coda\)$"
+}
+
+have_bin_ip=0
+if [ -x /sbin/ip ]; then
+  have_bin_ip=1
+  BROADCAST="broadcast +"
+fi
+
+[ -n "$broadcast" ] && BROADCAST="broadcast $broadcast"
+
+case "$1" in
+	deconfig)
+		if [ -x /sbin/resolvconf ]; then
+			/sbin/resolvconf -d "${interface}.udhcpc"
+		fi
+		if ! root_is_nfs ; then
+                        if [ $have_bin_ip -eq 1 ]; then
+                                /sbin/ip -4 addr flush dev $interface
+                                /sbin/ip link set dev $interface up
+                        else
+                                /sbin/ifconfig $interface 0.0.0.0
+                        fi
+		fi
+		;;
+
+	renew|bound)
+                if [ $have_bin_ip -eq 1 ]; then
+                        /sbin/ip addr add dev $interface local $ip/$mask $BROADCAST
+                else
+                        /sbin/ifconfig $interface $ip $BROADCAST $NETMASK
+                fi
+
+		if [[ "$interface" != p2p* ]]; then
+			if [ -n "$router" ] ; then
+				if ! root_is_nfs ; then
+					if [ $have_bin_ip -eq 1 ]; then
+						while /sbin/ip route del default dev $interface 2>/dev/null ; do
+							:
+						done
+					else
+						while /sbin/route del default gw 0.0.0.0 dev $interface 2>/dev/null ; do
+							:
+						done
+					fi
+				fi
+
+				metric=10
+				for i in $router ; do
+					if [ $have_bin_ip -eq 1 ]; then
+						/sbin/ip route add default via $i metric $metric dev $interface
+					else
+						/sbin/route add default gw $i dev $interface metric $metric 2>/dev/null
+					fi
+					metric=$(($metric + 1))
+				done
+			fi
+		else
+			echo "`date +"%b %d %T.%6N"` : udhcpc : default gw add/remove ignored for P2P[$interface]"
+			echo "`date +"%b %d %T.%6N"` : udhcpc : default gw add/remove ignored for P2P[$interface]" >> /opt/logs/wpa_p2p_supplicant.log
+		fi
+
+		# Update resolver configuration file
+		R=""
+		[ -n "$domain" ] && R="domain $domain
+"
+		for i in $dns; do
+			echo "$0: Adding DNS $i"
+			R="${R}nameserver $i
+"
+		done
+
+		if [[ "$interface" != p2p* ]]; then
+			if [ -x /sbin/resolvconf ]; then
+				echo -n "$R" | /sbin/resolvconf -a "${interface}.udhcpc"
+			else
+				#echo -n "$R" > "$RESOLV_CONF"
+                                echo "`date +"%b %d %T.%6N"` : udhcpc : WARNING DNS updation ignored for Non-P2P[$interface]" >> /opt/logs/wpa_p2p_supplicant.log
+			fi
+		else
+			echo "`date +"%b %d %T.%6N"` : udhcpc : DNS updation ignored for P2P[$interface]"
+			echo "`date +"%b %d %T.%6N"` : udhcpc : DNS updation ignored for P2P[$interface]" >> /opt/logs/wpa_p2p_supplicant.log
+		fi
+		;;
+esac
+
+exit 0

--- a/recipes-connectivity/wlan-p2p/wlan-p2p.bb
+++ b/recipes-connectivity/wlan-p2p/wlan-p2p.bb
@@ -7,6 +7,7 @@ DEPENDS = "wpa-supplicant"
 SRC_URI = "\
         file://wlan-p2p.sh \
         file://wlan-p2p.service \
+        file://p2p_udhcpc.script \
         "
 S = "${WORKDIR}"
 
@@ -23,13 +24,17 @@ do_install () {
     install -d ${D}${bindir}
     install -d ${D}${sbindir}
     install -d ${D}${systemd_unitdir}/system
+    install -d ${D}${sysconfdir}
+    install -d ${D}${sysconfdir}/wifi_p2p
 
     install -m 0755 ${S}/wlan-p2p.sh ${D}${bindir}
     install -m 0644 ${S}/wlan-p2p.service ${D}${systemd_unitdir}/system/wlan-p2p.service
     ln -sf ${sbindir}/wpa_supplicant ${D}${sbindir}/wpa_p2p_supplicant
+    install -m 0755 ${S}/p2p_udhcpc.script ${D}${sysconfdir}/wifi_p2p/udhcpc.script
 }
 
 SYSTEMD_SERVICE:${PN} = "wlan-p2p.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 FILES:${PN} += "${systemd_unitdir}/system/wlan-p2p.service"
 FILES:${PN} += "${sbindir}/wpa_p2p_supplicant"
+FILES:${PN} += "${sysconfdir}/wifi_p2p/udhcpc.script"


### PR DESCRIPTION
Reason for change: udhcpc script installation missed from rootfs

Risks: low

Signed-off-by: rajesh_gangadharan@comcast.com