### PR TITLE
RDKEMW-3466 : Run Viper JSPP Integrated Player in RDK NativeScript

### DIFF
--- a/recipes-graphics/uwebsockets/files/0001-libuv-makefile.patch
+++ b/recipes-graphics/uwebsockets/files/0001-libuv-makefile.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index ff68173..10b3259 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,8 @@
+ CPP_SHARED := -std=c++11 -O3 -I src -shared -fPIC src/Extensions.cpp src/Group.cpp src/Networking.cpp src/Hub.cpp src/Node.cpp src/WebSocket.cpp src/HTTPSocket.cpp src/Socket.cpp src/Epoll.cpp src/Room.cpp
+ CPP_OPENSSL_OSX := -L/usr/local/opt/openssl/lib -I/usr/local/opt/openssl/include
+ CPP_OSX := -stdlib=libc++ -mmacosx-version-min=10.7 -undefined dynamic_lookup $(CPP_OPENSSL_OSX)
++DEFS = -DUSE_LIBUV
++CFLAGS += $(DEFS)
+
+ default:
+        make `(uname -s)`
+

--- a/recipes-graphics/uwebsockets/uwebsockets_git.bb
+++ b/recipes-graphics/uwebsockets/uwebsockets_git.bb
@@ -8,7 +8,9 @@ S = "${WORKDIR}/git"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 #Apr 22 2018
 SRC_URI = "git://github.com/uNetworking/uWebSockets.git;branch=v0.14 \
+           file://0001-libuv-makefile.patch
           "
+
 SRCREV = "c7aa984726e41aa37a7dd75b76e45113759199ee"
 #SRC_URI[sha256sum] = "f1981bedabb71995641529986570c69be873d3f148b34e865876e4fd34b389b9"
 


### PR DESCRIPTION
Reason for change: LibUV was not linked to uwebsocket
Test Procedure: build should be successful.
Risks: low
Priority: P2