### PR TITLE
RDKEMW-4182: RDKMW-Getting Return code logs in wpaframework log

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/Activating_plugins_Logs_COMRPC.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/Activating_plugins_Logs_COMRPC.patch
@@ -27,6 +27,6 @@ index 15cc523cd..88f3af798 100644
          else {
              result = Core::ERROR_PRIVILIGED_REQUEST;
          }
-+        SYSLOG(Logging::Startup, (_T("Activating plugin [%u] returned code"),result));
++        SYSLOG(Logging::Startup, (_T("Activating plugin [%s] returned %u"),callsign.c_str(), result));
          return result;
      }


### PR DESCRIPTION
Reason for change: Updated the Callsign and correct the return logs
Test Procedure: please referred from the ticket
Risks: Medium
Signed-off-by: Thamim Razith <ThamimRazith_AbbasAli@comcast.com>