### PR TITLE
RDKEMW-4100 - NetworkManager Plugin Release - 0.19.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.18.0"
+PV = "0.19.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# May 21, 2025
-SRCREV = "f7344c0481df8e9e083f1653893274a932ab51a3"
+# May 29, 2025
+SRCREV = "2a0a4e32be46f1228f9722e97c63e8f25cc349ce"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.19.0 with following Bug fixes
- Fixed Persistence related to interface enable/disable status
- Added addtional logs to understand WIFISignal monitoring thread