### PR TITLE
    RDKEMW-3466 : Run Viper JSPP Integrated Player in RDK NativeScript

### DIFF
--- a/recipes-graphics/uwebsockets/uwebsockets_git.bb
+++ b/recipes-graphics/uwebsockets/uwebsockets_git.bb
@@ -16,7 +16,10 @@ DEPENDS = "openssl libuv zlib"
 
 do_compile() {
   cd  ${S}
-  make -f Makefile
+  DEFS=" -DUSE_LIBUV"
+  CFLAGS="$CFLAGS $DEFS"
+  make -f Makefile CFLAGS="$CFLAGS"
+
 }
 
 do_install() {


### PR DESCRIPTION
    Reason for change: LibUV was not linked to uwebsocket
    Test Procedure: build should be successful.
    Risks: low
    Priority: P2