### PR TITLE
RDKEMW-3788: Add WhoAmI support to DeviceProvisioning (meta-rdk-video)

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -17,7 +17,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
           "
 
 # Release version - 1.2.1
-SRCREV = "12218216fba1bdb61914a83957a5c1f69a786d22"
+SRCREV = "779080a1f08c9fb810c6585694ee135ed4d132af"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -17,7 +17,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
           "
 
 # Release version - 1.2.1
-SRCREV = "779080a1f08c9fb810c6585694ee135ed4d132af"
+SRCREV = "b62da73564f3a0adf8edda00071c4117b8d8dd80"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/wpe-framework/entservices-apis/RDKEMW-1007.patch
+++ b/recipes-extended/wpe-framework/entservices-apis/RDKEMW-1007.patch
@@ -1,7 +1,7 @@
 diff -uprN a/apis/AuthService/IAuthService.h b/apis/AuthService/IAuthService.h
 --- a/apis/AuthService/IAuthService.h	1970-01-01 03:00:00.000000000 +0300
 +++ b/apis/AuthService/IAuthService.h	2025-03-03 23:14:51.704577261 +0200
-@@ -0,0 +1,459 @@
+@@ -0,0 +1,466 @@
 +/*
 + * If not stated otherwise in this file or this component's LICENSE file the
 + * following copyright and licenses apply:
@@ -56,6 +56,12 @@ diff -uprN a/apis/AuthService/IAuthService.h b/apis/AuthService/IAuthService.h
 +        // @text serviceAccessTokenChanged
 +        // @brief The service access token has changed.
 +        virtual void ServiceAccessTokenChanged() = 0;
++        // @text onPartnerIdChanged
++        // @brief The Partner ID has changed.
++        // @param oldPartnerId old partner ID
++        // @param newPartnerId new partner ID
++        // @param isNew whether this is a new partner ID (not a change)
++        virtual void OnPartnerIdChanged(const string& oldPartnerId, const string& newPartnerId, const bool isNew) = 0;
 +    };
 +
 +    virtual uint32_t Register(IAuthService::INotification* notification /* @in */) = 0;
@@ -461,3 +467,4 @@ diff -uprN a/apis/AuthService/IAuthService.h b/apis/AuthService/IAuthService.h
 +
 +} // namespace Exchange
 +} // namespace WPEFramework
++


### PR DESCRIPTION
Reason for change: missing WAI support in RDK-E
Test Procedure: described in the ticket
Implements: code changes in AuthService and DeviceProvisioning
Risks: No
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending
Signed-off-by: Sergiy Gladkyy <sgladkyy@productengine.com>

Fixed a missing new line in the patch

Updated patch file

(cherry picked from commit d8a1c5f6817a1b7e9f123cfcde6eb5b9181a4f71)