### PR TITLE
[RDKEMW-4998] The DAC server URL to be updated back to consult red server

### DIFF
--- a/recipes-extended/entservices/include/entservices-lisa-dac-config.inc
+++ b/recipes-extended/entservices/include/entservices-lisa-dac-config.inc
@@ -47,7 +47,7 @@ def get_lisa_dac_config(d):
                 return machine_config_map_kirkstone[key]
         return '',''
 
-CONFIG_URL ?= ""
+CONFIG_URL ?= "https://280222515084-rdkm-apps-resources.s3.eu-central-1.amazonaws.com/configuration/cpe.json"
 LISA_DAC_CONFIG_PLATFORM ?= "${@get_lisa_dac_config(d)[0]}"
 LISA_DAC_CONFIG_FIRMWARE ?= "${@get_lisa_dac_config(d)[1]}"
 


### PR DESCRIPTION
Reason for change: Update the config url for DAC server.
Test Procedure: Build and Verified.
Risks: None.
Signed-off-by: [Sharnetha_SK@comcast.com](mailto:Sharnetha_SK@comcast.com)