### PR TITLE
RDK-57157: Prototype to improve NTP (timesyncd) reliability

### DIFF
--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -151,6 +151,14 @@ do_install() {
         install -m 0644 ${S}/systemd_units/zram.service ${D}${systemd_unitdir}/system
 
 
+	install -m 0644 ${S}/systemd_units/connectivitycheck.path ${D}${systemd_unitdir}/system
+	install -m 0644 ${S}/systemd_units/connectivitycheck.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${S}/systemd_units/myservice.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${S}/systemd_units/ntp-sync.path ${D}${systemd_unitdir}/system
+	install -m 0644 ${S}/systemd_units/ntp-sync.target ${D}${systemd_unitdir}/system
+	install -m 0644 ${S}/systemd_units/ntp-sync.timer ${D}${systemd_unitdir}/system
+	install -m 0644 ${S}/systemd_units/systime-set.path ${D}${systemd_unitdir}/system
+	install -m 0644 ${S}/systemd_units/systime-set.target ${D}${systemd_unitdir}/system
 
         if [ "${BIND_ENABLED}" = "true" ]; then
            echo "BIND_ENABLED=true" >> ${D}${sysconfdir}/device-middleware.properties


### PR DESCRIPTION
Reason for change: Improve NTP.
Test Procedure:
Risks: High
Priority: P1