### PR TITLE
RDKEMW-2278 : Removal of WPEFrameworkSecurity Agent Utility & related…

### DIFF
--- a/recipes-extended/aamp/aamp_git.bb
+++ b/recipes-extended/aamp/aamp_git.bb
@@ -38,6 +38,7 @@ PACKAGECONFIG:append = " playready widevine clearkey"
 DISTRO_FEATURES_CHECK = "wpe_r4_4 wpe_r4"
 EXTRA_OECMAKE += "${@bb.utils.contains_any('DISTRO_FEATURES', '${DISTRO_FEATURES_CHECK}', ' -DUSE_THUNDER_R4=ON', '', d)}"
 EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'subtec', '-DCMAKE_GST_SUBTEC_ENABLED=1 ', '', d)}"
+EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_security_util_disable', ' -DDISABLE_SECURITY_TOKEN=ON ', '', d)}"
 
 EXTRA_OECMAKE += "  -DCMAKE_WPEFRAMEWORK_REQUIRED=1 "
 
@@ -58,7 +59,9 @@ FILES:${PN} +="${libdir}/gstreamer-1.0/lib*.so"
 FILES:${PN}-dbg +="${libdir}/gstreamer-1.0/.debug/*"
 
 INSANE_SKIP:${PN} = "dev-so"
-CXXFLAGS += "-DCMAKE_LIGHTTPD_AUTHSERVICE_DISABLE=1 -I${STAGING_DIR_TARGET}${includedir}/WPEFramework/ -lWPEFrameworkSecurityUtil"
+CXXFLAGS += "-DCMAKE_LIGHTTPD_AUTHSERVICE_DISABLE=1 -I${STAGING_DIR_TARGET}${includedir}/WPEFramework/ "
+
+CXXFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_security_util_disable', '', ' -lWPEFrameworkSecurityUtil ', d)}"
 EXTRA_OECMAKE += " -DCMAKE_LIGHTTPD_AUTHSERVICE_DISABLE=1 "
 
 CXXFLAGS += " -DAAMP_BUILD_INFO=${AAMP_RELEASE_TAG_NAME}" 

--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -24,6 +24,8 @@ TOOLCHAIN = "gcc"
 DISTRO_FEATURES_CHECK = "wpe_r4_4 wpe_r4"
 EXTRA_OECMAKE += "${@bb.utils.contains_any('DISTRO_FEATURES', '${DISTRO_FEATURES_CHECK}', ' -DUSE_THUNDER_R4=ON', '', d)}"
 
+EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_security_util_disable', ' -DDISABLE_SECURITY_TOKEN=ON', '', d)}"
+
 EXTRA_OECMAKE += " -DPLUGIN_ANALYTICS_SIFT_STORE_PATH=/opt/persistent/AnalyticsSiftStore"
 
 DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'RDKE_PLATFORM_TV', "tvsettings-hal-headers ", "", d)}"

--- a/recipes-extended/entservices/entservices-softwareupdate.bb
+++ b/recipes-extended/entservices/entservices-softwareupdate.bb
@@ -28,6 +28,8 @@ RDEPENDS:${PN} += "wpeframework"
 
 TARGET_LDFLAGS += " -Wl,--no-as-needed -ltelemetry_msgsender -Wl,--as-needed "
 
+EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_security_util_disable', ' -DDISABLE_SECURITY_TOKEN=ON', '', d)}"
+
 CXXFLAGS += " -I${STAGING_DIR_TARGET}${includedir}/wdmp-c/ "
 CXXFLAGS += " -I${STAGING_DIR_TARGET}${includedir}/trower-base64/ "
 CXXFLAGS += " -DRFC_ENABLED "

--- a/recipes-extended/xdial/xdial.bb
+++ b/recipes-extended/xdial/xdial.bb
@@ -12,13 +12,16 @@ PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/xdialserver;protocol=${CMF_GIT_PROTOCOL};branch=develop"
 
-# Mar 26, 2025
-SRCREV = "a52d864df82b4dadd1b622067d79050b96d7a96d"
+# Apr 23, 2025
+SRCREV = "8a97f283f5382214184316bd63cfa03996d60550"
 
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 EXTRA_OEMAKE+= "PLATFORM_FLAGS="-DPLATFORM=-DNETFLIX_CALLSIGN_0=1""
+
+# Enable DISABLE_SECURITY_TOKEN
+EXTRA_OEMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_security_util_disable', '"DISABLE_SECURITY_TOKEN="-DDISABLE_SECURITY_TOKEN=1""', ' ', d)}"
 
 DEPENDS:append =  " ${@bb.utils.contains('DISTRO_FEATURES', 'enable_libsoup3', ' libsoup ', ' libsoup-2.4 ', d)}"
 DEPENDS:append = " gssdp"


### PR DESCRIPTION
… patches (#105)

* RDKEMW-2278 : Removal of WPEFrameworkSecurity Agent Utility & related patches

Reason for change: Removed the WPEFrameworkSecurity agent Utility
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1


* Updated the Xdial Server changes

* update the aamp changes for wpeframeworkSecurity Utility removal

* Updated the entservices-softwareupdate component git hash id for removal of wpeframeworksecurity utility

* Fixed thre Xdial Component Error

* Updated the entservices-infra and entservices-swupdate bb files

* Update the latest entservice-infra bb files

* Updated Rebased Entservices-infra

* updated  the RDKEMW-2278: Removal of WPEFrameworkSecurity Agent Utility

* Updated the latest entservices-infra and entservices-software bb changes

* Updated the 001-RDK-28534-Security-Agent-Utility-and-Logging.patch and 0001-RDK-28534-Security-Agent-Utility-and-Logging-ClientLibs.patch under the distro

* Updated the entservices-infra,entservices-softwareupdate,xdial

* Updated the entservices-sotwareupdate and aamp latest merged version

* Passed Compiler flag into CXXFlags, its not working, I moved to ECMake is working as like below

* RDKEMW-2278 : Removal of WPEFrameworkSecurity Agent Utility & related patches

Reason for change: Added back  the WPEFrameworkSecurity agent Utility patches for merging the other changes
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1

* Updated the spaces in bb files

---------