### PR TITLE
RDKEMW-5238: Remove LISA patch and configure persistent path

### DIFF
--- a/recipes-extended/entservices/entservices-lisa.bb
+++ b/recipes-extended/entservices/entservices-lisa.bb
@@ -13,23 +13,11 @@ DEPENDS += "wpeframework boost curl libarchive wpeframework-tools-native entserv
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = "${CMF_GITHUB_ROOT}/LISA;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MAIN_BRANCH}"
-SRC_URI += "file://0100-update-config.patch;apply=no"
-
-do_lisa_patches() {
-    cd ${S}
-    if [ -e ${WORKDIR}/0100-update-config.patch ]; then
-        if [ ! -e lisa_patch_0100_applied ]; then
-            bbnote "Patching 0100-update-config.patch"
-            patch -p1 < ${WORKDIR}/0100-update-config.patch
-            touch lisa_patch_0100_applied
-        fi
-    fi
-}
-addtask lisa_patches after do_unpack before do_configure
 
 TOOLCHAIN = "gcc"
 EXTRA_OECMAKE += "-DCMAKE_SYSROOT=${STAGING_DIR_HOST}"
 EXTRA_OECMAKE += "-DBUILD_REFERENCE=${SRCREV}"
+EXTRA_OECMAKE += "-DPLUGIN_LISA_PATH=${LISA_PATH}"
 
 # 18 Dec 2023 or head
 SRCREV = "f0888c8f5a3919540952fb24cc466cfc97d08f07"

--- a/recipes-extended/entservices/include/entservices-lisa-dac-config.inc
+++ b/recipes-extended/entservices/include/entservices-lisa-dac-config.inc
@@ -51,6 +51,9 @@ CONFIG_URL ?= "https://280222515084-rdkm-apps-resources.s3.eu-central-1.amazonaw
 LISA_DAC_CONFIG_PLATFORM ?= "${@get_lisa_dac_config(d)[0]}"
 LISA_DAC_CONFIG_FIRMWARE ?= "${@get_lisa_dac_config(d)[1]}"
 
+LISA_DEFAULT_PATH ?= "/opt"
+LISA_PATH ?= "${@d.getVar('PRODUCT_CONF_LISA_PATH') or d.getVar('LISA_DEFAULT_PATH') }"
+
 python do_inject_dac_config() {
     import json
 


### PR DESCRIPTION
Reason for change: Realtek VA requires the installation path for DAC Apps to be /tmp/data so adding variable that can be configured from product layer

Test Procedure: Build and verify.

Risks: Low