### PR TITLE
RDKEMW-2565 Add deviceIdentification plugin details into deviceinfo

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
           "
 
 # Release version - 3.0.0
-SRCREV = "f5d857cc7b9dee52386151b162154ce62b7830c4"
+SRCREV = "946ac802c27777fccd5198b77fe32a60c329d33d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -14,7 +14,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name
 SRC_URI += "file://RDKEMW-1007.patch"
 
 # Tag 1.6.0
-SRCREV_entservices-apis = "fac3205e2a99871014f65f2f91128456f22e60ee"
+SRCREV_entservices-apis = "2d85368485bfee1d59aa52350773fa982759d180"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: Add chipset and ReleaseVersion property to DeviceInfo Plugin
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: [ramkumar_prabaharan@comcast.com](mailto:ramkumar_prabaharan@comcast.com)