### PR TITLE
RDKEMW-5327: Upgrade Cobalt 25 Larboard

### DIFF
--- a/recipes-extended/cobalt/larboard_revision.inc
+++ b/recipes-extended/cobalt/larboard_revision.inc
@@ -3,5 +3,5 @@ LARBOARD_SRC_URI = "${CMF_GITHUB_ROOT}/larboard"
 # 24.lts.stable. March 13, 2025
 LARBOARD_SRCREV_24 ?= "10f8d522b8a26727bc03dfe1e3f619bad91df5c3"
 
-# develop. April 2, 2025
-LARBOARD_SRCREV_DEV ?= "1.0.1-dev"
+# develop. Jun 17, 2025
+LARBOARD_SRCREV_DEV ?= "1.0.2"


### PR DESCRIPTION
Reason for change: Cobalt 25 maintenance
Test Procedure: N/A
Risks: None

Change-Id: I4ffd94c08fb58a9fbe496f2cc6221a99032d1856