### PR TITLE
RDK7RM-100: EntServices : DeviceInfo.modelid,make and socname APIs return ERROR_GENERAL response.

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.9-RDK7.1 from support/rdk7-main
-SRCREV = "393bc6f0eefe91d497737a092ee67fa0a2e56c5c"
+# Release version - 1.0.9-RDK7.2 from support/rdk7-main
+SRCREV = "47dbc793b192b28bfc3d22d91c9db0d4f1fe9307"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/wpe-framework/rdkservices-apis_1.0.bb
+++ b/recipes-extended/wpe-framework/rdkservices-apis_1.0.bb
@@ -12,8 +12,8 @@ DEPENDS = "wpeframework wpeframework-tools-native"
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name=entservices-apis"
 SRC_URI += "file://RDKEMW-1007.patch"
 
-# Tag 1.3.1
-SRCREV_entservices-apis = "7d2bee44e02850ee77539e3173772c6c2d1f2adc"
+# Tag 1.3.1-RDK7.1 from support/rdk7-main
+SRCREV_entservices-apis = "7cb2e483d0ab9e4ae3a8778d9d286ec702abf8cb"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
**Reason for change:** Update the SRC_REV for entservices-deviceanddisplay and entservices-apis component.
**Test Procedure:** Build and verify
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com