### PR TITLE
RDK-57197: Upadate Analytics config with no backend

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -59,7 +59,6 @@ PACKAGECONFIG ?= " monitor \
     usbdevice \
     usbmass_storage \
     usersettings \
-    analytics \
     ocicontainer \
     runtimemanager \
     messagecontrol \
@@ -119,7 +118,7 @@ PACKAGECONFIG[usbaccess]            = "-DPLUGIN_USBACCESS=ON,-DPLUGIN_USBACCESS=
 PACKAGECONFIG[usbdevice]         = "-DPLUGIN_USBDEVICE=ON,-DPLUGIN_USBDEVICE=OFF,libusb1"
 PACKAGECONFIG[usbmass_storage]         = "-DPLUGIN_USB_MASS_STORAGE=ON,-DPLUGIN_USB_MASS_STORAGE=OFF,"
 PACKAGECONFIG[usersettings]         = "-DPLUGIN_USERSETTINGS=ON,-DPLUGIN_USERSETTINGS=OFF,"
-PACKAGECONFIG[analytics]            = "-DPLUGIN_ANALYTICS=ON -DPLUGIN_ANALYTICS_SIFT_BACKEND=ON,-DPLUGIN_ANALYTICS=OFF,curl entservices-apis,curl entservices-apis"
+PACKAGECONFIG[analytics]            = "-DPLUGIN_ANALYTICS=ON,-DPLUGIN_ANALYTICS=OFF, entservices-apis, entservices-apis"
 PACKAGECONFIG[rdkshell]             = "-DPLUGIN_RDKSHELL=ON,-DPLUGIN_RDKSHELL=OFF,rdkshell entservices-apis,rdkshell entservices-apis"
 PACKAGECONFIG[rdkshellrialto]       = "-DRIALTO_FEATURE=ON,-DRIALTO_FEATURE=OFF,rialto,rialto-servermanager-lib"
 PACKAGECONFIG[rustadapter]          = "-DPLUGIN_RUSTADAPTER=ON,,,"


### PR DESCRIPTION
Reason for change: Upadate Analytics config,
 where backend is not set
Test Procedure: build and use Analytics api
Priority: P1
Risks: Low

Change-Id: I75498df9ee180e06a3e1292359ac17ea31839fe1