### PR TITLE
RDKEMW-5316: To list AV1 codec from PlayerInfo

### DIFF
--- a/recipes-extended/entservices/entservices-mediaanddrm.bb
+++ b/recipes-extended/entservices/entservices-mediaanddrm.bb
@@ -24,8 +24,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-mediaanddrm;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-set-OCDM-process-thread-name.patch \
           "
 
-# Release version - 1.1.2
-SRCREV = "0a13b154f317914656c99296c7f25ed7884947e9"
+# Release version - 1.1.3
+SRCREV = "4ac8802aa0190b8bc9dab1f000f2a2558169cb75"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -13,8 +13,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name
 
 SRC_URI += "file://RDKEMW-1007.patch"
 
-# Tag 1.7.3
-SRCREV_entservices-apis = "7226f3bebe52944b9bc995fcbfe07f476a1d7f62"
+# Tag 1.7.4
+SRCREV_entservices-apis = "d71c96a2bf93ada23bec6967bb8595db6e7d0abe"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason For Change: PlayerInfo service doesn't report AV1 codec though platform supports
Test procedure: Mentioned in the ticket RDKTV-35827
Risks: Low
Signed-off-by: vidhathri.joshi@gmail.com