### PR TITLE
RDKEMW-5316 : PlayerInfo service doesn't report AV1 codec though plat…

### DIFF
--- a/recipes-extended/entservices/entservices-mediaanddrm.bb
+++ b/recipes-extended/entservices/entservices-mediaanddrm.bb
@@ -25,7 +25,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-mediaanddrm;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.1.2
-SRCREV = "0a13b154f317914656c99296c7f25ed7884947e9"
+SRCREV = "6ce5ee47d585b79a360731e0d89c3a256e5d8aac"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -14,7 +14,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name
 SRC_URI += "file://RDKEMW-1007.patch"
 
 # Tag 1.7.1
-SRCREV_entservices-apis = "b3f943f09ee7defc93c6d42065574b650a611ea5"
+SRCREV_entservices-apis = "0758ab16830d1fb995ecbbe0cd1a411f32533f22"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
…from supports

Reason for change: To report AV1 codec from PlayerInfo service
Test Procedure: Codec support should be reported from command
Risks: No Risks
Priority: P1