### PR TITLE
RDKEMW-2444 - NetworkManager Plugin Release - 0.20.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.19.0"
+PV = "0.20.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# May 29, 2025
-SRCREV = "2a0a4e32be46f1228f9722e97c63e8f25cc349ce"
+# June 20, 2025
+SRCREV = "17cc46d26716aecf30a3dcad3a577f39dc95d000"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.20.0 with following Bug fixes
- Fixed the bug in Resetting of Manual IPv4
- Fixed the SSID Name Length Check
- Added Connectivity Improvement
- Fixed the WiFi Signal Monitor thread exception
- Fixed documentation of GetSupportedSecurityModes
- Fixed the WiFi Migration settings