### PR TITLE
RDKEMW-5512: Implement a fix for the SaveTVDimmingMode failure

### DIFF
--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.3.0
-SRCREV = "bbf60a99fefb3a788c10b93c211d24ddd08e2a03"
+# Release version - 1.3.1
+SRCREV = "ace4f1fe6afe6e30cbd14239d3480199aeeaf809"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.3.0
-SRCREV = "2499e0b71c2fbb9e9a303a342fbc4965da5b52c9"
+SRCREV = "bbf60a99fefb3a788c10b93c211d24ddd08e2a03"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
JIRA ticket related to this changes is https://ccp.sys.comcast.net/browse/RDKEMW-5512

Test results can be found here: https://ccp.sys.comcast.net/browse/RDKEMW-5512?focusedId=22517278&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22517278



Corresponding vendor changes were earlier merged and the details can be found here:

Tvsettings HAL
[RDKTV-33767: Remove ODM specific apis - phase2 by arjun-binu_comcast · Pull Request #17 · rdk-e/tvsettings-soc-amlogic](https://github.com/rdk-e/tvsettings-soc-amlogic/pull/17)


Meta PRs:

[RDKTV-33767: ODM specific apis removal in tvsettings-hal by arjun-binu_comcast · Pull Request #571 · rdk-e/meta-rdk-vendor-oem-sky-amlogic-common](https://github.com/rdk-e/meta-rdk-vendor-oem-sky-amlogic-common/pull/571)

[RDKTV-33767: ODM specific apis removal in tvsettings-hal-headers by arjunbinu · Pull Request #44 · rdkcentral/meta-rdk-halif-headers](https://github.com/rdkcentral/meta-rdk-halif-headers/pull/44)