### PR TITLE
RDKEMW-5510: Integrate the ODM Phase 2 middleware changes into RDKE

### DIFF
--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.3.1
-SRCREV = "2b418b1f884274939cbe2dea8f730d5fc853edbd"
+# Release version - 1.3.2
+SRCREV = "c8d5cfd654857554b4ea67a989e5f0b07f4a2831"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.3.1
-SRCREV = "05ceab6e0cf108088aafb5175218537d7cdf5ef5"
+SRCREV = "2b418b1f884274939cbe2dea8f730d5fc853edbd"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.3.0
-SRCREV = "2499e0b71c2fbb9e9a303a342fbc4965da5b52c9"
+SRCREV = "69edf7411fd5ea9704dc263a6818d53f1d030e28"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
JIRA ticket related to this changes is https://ccp.sys.comcast.net/browse/RDKEMW-5510

Test results can be found here: 
https://ccp.sys.comcast.net/browse/RDKEMW-5510?focusedId=22569576&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22569576

Corresponding vendor changes were earlier merged and the details can be found here:

Tvsettings HAL
[RDKTV-33767: Remove ODM specific apis - phase2 by arjun-binu_comcast · Pull Request #17 · rdk-e/tvsettings-soc-amlogic](https://github.com/rdk-e/tvsettings-soc-amlogic/pull/17)

Meta PRs:

[RDKTV-33767: ODM specific apis removal in tvsettings-hal by arjun-binu_comcast · Pull Request #571 · rdk-e/meta-rdk-vendor-oem-sky-amlogic-common](https://github.com/rdk-e/meta-rdk-vendor-oem-sky-amlogic-common/pull/571)

https://github.com/rdkcentral/meta-rdk-halif-headers/pull/44