### PR TITLE
RDKEMW-3229: Update Power manager plugin interface clean up

### DIFF
--- a/recipes-extended/entservices/entservices-peripherals.bb
+++ b/recipes-extended/entservices/entservices-peripherals.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-peripherals;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.0.5
-SRCREV = "f9180349a26d740cddeb8ef79cddd46379325cf7"
+SRCREV = "ebd8f03fa4c44a27542e72990a0605e8aeb7ea12"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: Replace the IARM Power Manager from Power Manager functionality. Test Procedure: Updated in the Jira
Risks: Low
Signed-off-by:Ramesh Babu H bp-rbabu299@cable.comcast.com