### PR TITLE
RDKEMW-2303: Update gst-svp-ext version

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0001-DELIA-64727-Prealloc-secure-memory-before-decrypt.patch
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0001-DELIA-64727-Prealloc-secure-memory-before-decrypt.patch
@@ -1,0 +1,39 @@
+From aa880f1ffe13124b2fc05978dc9603573d497f61 Mon Sep 17 00:00:00 2001
+From: Callum Wilson <callum_wilson@comcast.com>
+Date: Thu, 20 Mar 2025 14:15:04 +0000
+Subject: [PATCH] DELIA-64727-Prealloc-secure-memory-before-decrypt
+
+---
+ Source/ocdm/adapter/rdk/open_cdm_adapter.cpp | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp b/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp
+index d42bb80..9d1948f 100644
+--- a/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp
++++ b/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp
+@@ -161,7 +161,7 @@ OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, G
+                 gsize dataBlockSize = gst_svp_allocate_data_block(session->SessionPrivateData(), (void**) &svpData, totalEncrypted, totalEncrypted);
+ 
+                 uint8_t* encryptedDataIter = reinterpret_cast<uint8_t *>(gst_svp_header_get_start_of_data(session->SessionPrivateData(), svpData));
+-                
++
+                 uint32_t index = 0;
+                 for (unsigned int position = 0; position < subSampleCount; position++) {
+ 
+@@ -432,7 +432,15 @@ OpenCDMError opencdm_gstreamer_session_decrypt_buffer(struct OpenCDMSession* ses
+ 
+             if(total_encrypted_bytes > 0) {
+                uint8_t* svpData;
+-               uint32_t dataBlockSize = gst_svp_allocate_data_block(session->SessionPrivateData(), (void**) &svpData, mappedDataSize, mappedDataSize);
++
++              const gboolean needSecureMemoryPrealloc = (streamProperties.media_type == MediaType_Video)
++                                                      && gst_svp_context_supports_memory_prealloc(session->SessionPrivateData());
++
++              uint32_t dataBlockSize = gst_svp_allocate_data_block(session->SessionPrivateData(),
++                                                                   (void**) &svpData,
++                                                                   mappedDataSize,
++                                                                   mappedDataSize,
++                                                                   needSecureMemoryPrealloc);
+ 
+                void * encryptedData = reinterpret_cast<uint8_t *>(gst_svp_header_get_start_of_data(session->SessionPrivateData(), svpData));
+ 

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
@@ -27,6 +27,7 @@ SRC_URI = "git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=https
            file://r4.4/0001-add-svp-header-to-data-before-decryption.patch \
            file://r4.4/0001-error-handling-if-session-is-not-valid.patch \
            file://r4.4/0001-Add-vault-platform-case.patch \
+           file://r4.4/0001-DELIA-64727-Prealloc-secure-memory-before-decrypt.patch \
           "
 
 # Oct 17, 2023


### PR DESCRIPTION
Reason for change:
RDK-V stable2 contains newer changes
that are missing in RDK-E. This
change brings in the secure memory
pre-allocation feature

Test Procedure:
Verify encrypted playback on all
apps across all platforms.

Priority: P0

Risks: High

Change-Id: Ice4eb38108e0500dfb5913d52670d6bda42b71aa