### PR TITLE
RDK-55760: Analyze and remove Audiocapturemgr binaries

### DIFF
--- a/recipes-extended/audiocapturemgr/audiocapturemgr_git.bb
+++ b/recipes-extended/audiocapturemgr/audiocapturemgr_git.bb
@@ -22,7 +22,6 @@ LDFLAGS:append = "-lprivilege"
 CXXFLAGS += " -DDROP_ROOT_PRIV"
 
 S = "${WORKDIR}/git"
-EXTRA_OECONF = " --enable-testapp "
 export RDK_FSROOT_PATH = '${STAGING_DIR_TARGET}'
 
 inherit autotools pkgconfig systemd breakpad-logmapper syslog-ng-config-gen


### PR DESCRIPTION
Reason for change : With this change ACM will avoid descending into the test directory and will not generate these debugging       
                                 aids.
Test Procedure       : Analyze if binaries are removed from RDKE rootfs
Priority                   : P1
Risks                      : None
Signed-off-by       : daya_christudasan@comcast.com

Change-Id: Ib891dcc21882ecef7ed4ae8c338ccdaaa7970efc