### PR TITLE
RDKEMW-5233 : Adding SHA ID to include latest entservices-infra

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -17,7 +17,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
           "
 
 # Release version - 1.4.8
-SRCREV = "094db70caaeb24ba992b77f6a703463f0e2ea22e"
+SRCREV = "7370767136b635e7450db6e19171f3995e16937e"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change : Adding SHA ID to include latest entservices-infra to include L1 test for AppManager
Test Procedure: YML run is successfull
Risks: Low
Priority: P1
Signed-off-by: Abhay Kant bp-akant305@cable.comcast.com