### PR TITLE
XIONE-17419: Network Manager-Remove Duplicate files

### DIFF
--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -261,6 +261,8 @@ do_install() {
 	install -m 0755 ${S}/lib/rdk/NM_Dispatcher.sh ${D}${sysconfdir}/NetworkManager/dispatcher.d
 	install -m 0755 ${S}/lib/rdk/NM_preDown.sh ${D}${sysconfdir}/NetworkManager/dispatcher.d/pre-down.d
 	install -m 0755 ${S}/etc/10-unmanaged-devices ${D}${sysconfdir}/NetworkManager/conf.d/10-unmanaged-devices.conf
+        rm ${D}${base_libdir}/rdk/NM_Dispatcher.sh
+        rm ${D}${base_libdir}/rdk/NM_preDown.sh
 }
 
 do_install:append:rdkstb() {


### PR DESCRIPTION
Reason for change: Remove duplicate files
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)