### PR TITLE
RDKEMW-5890: Remove autostart check from WPEFramework code to be handled by systemd

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/Removed_Autostart_Check_From_WPEFramework.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/Removed_Autostart_Check_From_WPEFramework.patch
@@ -1,0 +1,22 @@
+diff --git a/Source/WPEFramework/PluginServer.cpp b/Source/WPEFramework/PluginServer.cpp
+index 13fe9d59d..17ba9459f 100644
+--- a/Source/WPEFramework/PluginServer.cpp
++++ b/Source/WPEFramework/PluginServer.cpp
+@@ -1148,6 +1148,9 @@ POP_WARNING()
+           });
+
+         for (auto service : configured_services)
++            SYSLOG(Logging::Startup, (_T("Activation of plugin [%s]:[%s] handled by systemd"),
++                service->ClassName().c_str(), service->Callsign().c_str()));
++#if 0
+         {
+             if (service->State() != PluginHost::Service::state::UNAVAILABLE) {
+                 if (service->Startup() == PluginHost::IShell::startup::ACTIVATED) {
+@@ -1161,6 +1164,7 @@ POP_WARNING()
+                 }
+             }
+         }
++#endif
+ #ifdef SYSTEMD_FOUND
+         SYSLOG(Logging::Startup, (_T("Notify that WPEFramework Systemd Service is Ready")));
+         sd_notify(0, "READY=1");

--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -1,8 +1,6 @@
 [Unit]
 Description=wpeframework
-Wants=network-online.target local-fs.target
-After= network-online.target local-fs.target securemount.service
-RequiresMountsFor=/opt/secure
+DefaultDependencies=no
 
 [Service]
 Type=notify

--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=wpeframework
-DefaultDependencies=no
+Wants=network-online.target local-fs.target
+After= network-online.target local-fs.target securemount.service
+RequiresMountsFor=/opt/secure
 
 [Service]
 Type=notify

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -52,6 +52,7 @@ SRC_URI += "file://wpeframework-init \
            file://r4.4/Update-Trace-Level-Logging-Logic.patch \
            file://r4.4/Activating_plugins_Logs_COMRPC.patch \
            file://r4.4/FirmwareUpdate_UptoDate.patch \
+           file://r4.4/Removed_Autostart_Check_From_WPEFramework.patch \
            "
 
 SRC_URI += "file://r4.4/PR-1633-Clone-functionality-fix.patch \


### PR DESCRIPTION
Reason for change: Removed the autostart options to helps to handle the plugin by the systemd during bootup
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1