### PR TITLE
RDKEMW-5966 - [RDKE] RDKShell injectKey latency is higher with RDKSHELL_FRAMERATE set to 60

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -18,7 +18,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
 
 
 # Release version - 1.5.1
-SRCREV = "fd23a8d6eb9b4dcd8969d816cb9c8942e95b1e4d"
+SRCREV = "a98d0107253ea91ac289bdb24bfa95af37e5013d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: entservices-infra component SHA update on metalayer to run the CI verification.

Test Procedure: Verified the build.

Signed-off-by: thenmozhi_kathiravan@comcast.com