### PR TITLE
RDKEMW-5788 - Fix PreLoadApp API crash

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -18,7 +18,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
 
 
 # Release version - 1.5.7
-SRCREV = "e75f839d7c6df015f61fcf55e0965a97909058c8"
+SRCREV = "c1f0b1e4e87f8b54a6ab2879ebaf97d17f13fc4d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change : Fixed PreLoadApp API crash
Test Procedure: Run AppManager L1 test in github workflow and test in full stack
Risks: Medium
Priority: P1
Signed-off-by: Siva Thandayuthapani [sithanda@synamedia.com](mailto:sithanda@synamedia.com)