### PR TITLE
RDKEMW-3750 : Upgrade Thunder to Version R4.4.3

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 3.1.0
-SRCREV = "414733ef0209534558bf40161a98d9a0d2c1c463"
+# Release version - 3.1.1
+SRCREV = "a88b47e5e1c5d92579bcbf58b5a8442c2ddd7b37"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.3.2
-SRCREV = "c8d5cfd654857554b4ea67a989e5f0b07f4a2831"
+# Release version - 1.3.3
+SRCREV = "4b3a8e622f2620d7702d9288e1784b327843f5fe"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: pulled entservices-deviceanddisplay (3.1.1) and entservices-intputoutput(1.3.3)
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1