### PR TITLE
RDKEMW-5551: [AI2.0][AM] Fix getInstalledApps response having escape characters

### DIFF
--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -16,7 +16,7 @@ SRC_URI += "file://RDKEMW-1007.patch"
 
 
 # Tag 1.10.1
-SRCREV_entservices-apis = "d604d099351ea5473373529c8113ef6b1835ce62"
+SRCREV_entservices-apis = "8562c0c75e24154c6b8b53d4fb6d3dcb137dcaf7"
 
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change : Added @opaque tag in interface method to avoid adding escape characters
Test Procedure: Run AppManager L1 test in github workflow and test in full stack
Risks: Medium
Priority: P1
Signed-off-by: Siva Thandayuthapani [sithanda@synamedia.com](mailto:sithanda@synamedia.com)