### PR TITLE
RDKEMW-6061: Log the Thunder JSON RPC request including event

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/WPEFramework-LogJsonRpcCommunication.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/WPEFramework-LogJsonRpcCommunication.patch
@@ -1,0 +1,32 @@
+diff --git a/Source/plugins/JSONRPC.h b/Source/plugins/JSONRPC.h
+index 63329bb2..4167adca 100644
+--- a/Source/plugins/JSONRPC.h
++++ b/Source/plugins/JSONRPC.h
+@@ -354,7 +354,17 @@ namespace PluginHost {
+             _versions.emplace_back(name, major, minor, patch);
+         }
+
+-        //
++        // Methods to Count the JSONRPC Communication
++        // ------------------------------------------------------------------------------------------------------------------------------
++        void LogJsonRpcCommunication(const string& method, const string& parameters)
++        {
++            static std::atomic<uint32_t> Count{0};
++            Registration info;  info.FromString(parameters);
++            Count++;
++            SYSLOG(Logging::Startup, (_T("Total JSON-RPC requests : %u, call sign: %s, method: %s"), Count.load(), info.Callsign.Value().c_str(),method.c_str()));
++        }
++
++       //
+         // Methods to send outbound event messages
+         // ------------------------------------------------------------------------------------------------------------------------------
+         uint32_t Notify(const string& event) const
+@@ -496,7 +506,7 @@ namespace PluginHost {
+             else {
+                 result = Invoke(this, channelId, id, token, method, parameters, response);
+             }
+-
++            LogJsonRpcCommunication(method,parameters);
+             return (result);
+         }
+         void Activate(IShell* service) override

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -53,6 +53,7 @@ SRC_URI += "file://wpeframework-init \
            file://r4.4/Activating_plugins_Logs_COMRPC.patch \
            file://r4.4/FirmwareUpdate_UptoDate.patch \
            file://r4.4/Removed_Autostart_Check_From_WPEFramework.patch \
+           file://r4.4/WPEFramework-LogJsonRpcCommunication.patch \
            "
 
 SRC_URI += "file://r4.4/PR-1633-Clone-functionality-fix.patch \


### PR DESCRIPTION
Reason for change: Count the Thunder JSON RPC request including Events subscribing including method invoking such as activate, deactivate..so on.
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1