### PR TITLE
RDKEMW-6063 - NetworkManager Plugin Release - 0.22.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.21.0"
+PV = "0.22.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Jul 08, 2025
-SRCREV = "2c50c78583bb8efbc0b1396952fc9f10af0f930a"
+# Jul 14, 2025
+SRCREV = "8d2f75d9368b97e11de3066a679c5dbed47b1523"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.22.0 with following Bug fixes
- Fixed trigger point for the connectivity monitoring
- Posting onWiFiStateChange Event when link-up for wifi event is received.