### PR TITLE
RDKEMW-5551: Fix getInstalledApps response having escape characters

### DIFF
--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -15,8 +15,8 @@ SRC_URI += "file://RDKEMW-1007.patch"
 
 
 
-# Tag 1.11.0
-SRCREV_entservices-apis = "9558bbc520c6165dafc00131302ed0bb34396c8e"
+# Tag 1.12.0
+SRCREV_entservices-apis = "b6d37107534232a0ddfc1fea6458a6fb2339817f"
 
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change : Added @opaque tag in interface method to avoid adding escape characters
Test Procedure: Run AppManager L1 test in github workflow and test in full stack
Risks: Medium
Priority: P1
Signed-off-by: Siva Thandayuthapani [sithanda@synamedia.com](mailto:sithanda@synamedia.com)