### PR TITLE
RDKTV-37684: New sync up logic for updateAVoutputTVParam

### DIFF
--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.3.3
-SRCREV = "4b3a8e622f2620d7702d9288e1784b327843f5fe"
+SRCREV = "cd9c3064b6160fa02cf2aa9ac858b8f85fdfe713"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: moved the updateAVoutputTVParam to thread if sync/reset
Test Procedure: as per JIRA
Risks: None
Priority: P1