### PR TITLE
RDKEMW-5230: JSRuntimeLauncher component

### DIFF
--- a/recipes-graphics/rdknativescript/rdknativescript_git.bb
+++ b/recipes-graphics/rdknativescript/rdknativescript_git.bb
@@ -76,8 +76,10 @@ do_install() {
    install -d ${D}/${libdir}
    install -d ${D}${includedir}
    mkdir -p ${D}${includedir}/jsruntime
+   mkdir -p ${D}${includedir}/jsruntime/modules
 
    install -m 0644 ${S}/include/*.h ${D}${includedir}/jsruntime
+   cp -a ${D}/home/root/modules/* ${D}${includedir}/jsruntime/modules/
 }
 
 FILES:${PN} += "${libdir}/*.so"


### PR DESCRIPTION
Reason for change: copying modules to recipe-sysroot
Test Procedure: build should be successful.
Risks: low
Priority: P2