### PR TITLE
RDKEMW-6230: Improper portNumber assignment

### DIFF
--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.3.3
-SRCREV = "4b3a8e622f2620d7702d9288e1784b327843f5fe"
+SRCREV = "5a4f267852555b1f45fd24538cd20b13f56db506"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for Change: Fix crash from GetDeviceList
Test Procedure: Check for crash
Risks: Low
Priority: P1