### PR TITLE
RDKEMW-6446: Update ITextTrack interface to CC HAL

### DIFF
--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -16,7 +16,7 @@ SRC_URI += "file://RDKEMW-1007.patch"
 
 
 # Tag 1.11.0
-SRCREV_entservices-apis = "9558bbc520c6165dafc00131302ed0bb34396c8e"
+SRCREV_entservices-apis = "28064f68843f6204829f1045801b31d778b792f2"
 
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The next version of ITextTrack supports setting a session up to pull its own CC data directly from the HAL implementation.

Change-Id: I2a4ebe51604384ce2e143e48b39a9811fbd238f9