### PR TITLE
RDKEMW-6189,RDKEMW-6300,RDKEMW-6097,RDKEMW-5763,RDKEMW-5756 - NetworkManager Plugin Release - 0.23.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.22.0"
+PV = "0.23.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Jul 14, 2025
-SRCREV = "8d2f75d9368b97e11de3066a679c5dbed47b1523"
+# Jul 30, 2025
+SRCREV = "562ece896f27a6a93b309b1663e8316b82b401e4"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.23.0 with following Bug fixes
- Added L1/L2 workflow for LegacyNetwork, LegacyWiFi and NetworkManager Plugins
- Fixed RemoveKnownSSID method to handle the invalid inputs
- Fixed the logging in GetIPSettings