### PR TITLE
RDKEMW-6681: getDolbyVisionMode api fails to return "Dark/Bright" in …

### DIFF
--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.4.2
-SRCREV = "f27d63abc94c9cb7585e16979b2ce09b58961388"
+# Release version - 1.4.3
+SRCREV = "2028e5496e3c9dfc74d4a18fe365cac9da8f9295"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
getDolbyVisionMode api fails to return "Dark/Bright" in response for AVOutput plugins.

Reason for change: Added condition in getDolbyVisionMode() to return error for non DV content.
Test Procedure: as per JIRA
Risks: None
Priority: P2