### PR TITLE
RDKEMW-6701: Changed KillSignal to SIGKILL instead of SIGTERM

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -23,7 +23,7 @@ ExecStart=/bin/bash -c 'if [ -f /opt/WPEFramework/config.json ]; then exec /usr/
 # it will need corresponding code change in ThunderClientLibraries (power_controller) too.
 ExecStartPost=-/bin/sh -c '/bin/echo ${MAINPID} > /tmp/wpeframework.pid'
 ExecStartPost=/bin/touch /tmp/wpeframeworkstarted
-KillSignal=SIGTERM
+KillSignal=SIGKILL
 Restart=always
 
 [Install]


### PR DESCRIPTION
Reason for change: It appears that somethunder plugins are not stopping properly, which is causing an extended shutdown time.Since SIGTERM takes time to gracefully terminate the processes, we are changing the kill signal to SIGKILL for immediate termination.
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1