### PR TITLE
RDKEMW-6590: iarmbus recipe add enforce TIME_BITS as 64

### DIFF
--- a/recipes-extended/iarmmgrs/iarmmgrs_git.bb
+++ b/recipes-extended/iarmmgrs/iarmmgrs_git.bb
@@ -40,6 +40,10 @@ SYSLOG-NG_SERVICE_uimgr += "dsmgr.service mfrmgr.service sysmgr.service"
 #SYSLOG-NG_DESTINATION_uimgr = "uimgr_log.txt"
 #SYSLOG-NG_LOGRATE_uimgr = "very-high"
 
+# Y2K38_SAFETY Coverity Fix
+CFLAGS:append   = " -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64"
+CXXLAGS:append  = " -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64"
+
 #key-simulator
 CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'enable_eu_remote', ' -D_SKQ_KEY_MAP_1_', '', d)}"
 


### PR DESCRIPTION
Reason for Change: To fix the coverity error Y2K38_SAFETY, enforce the following Compile flags
- _TIME_BITS=64
- _FILE_OFFSET_BITS=64