### PR TITLE
RDKEMW-7056: Name OCDM decryption thread

### DIFF
--- a/recipes-extended/entservices/entservices-mediaanddrm.bb
+++ b/recipes-extended/entservices/entservices-mediaanddrm.bb
@@ -24,8 +24,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-mediaanddrm;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-set-OCDM-process-thread-name.patch \
           "
 
-# Release version - 1.3.0
-SRCREV = "d7cc83efe59f0ccd1496e99f2cde61a1605a2caf"
+# Release version - 1.3.1
+SRCREV = "3c529f29c4106717aeca9d309fb5387e85bde7fd"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: Enables OCDM decryption thread to be identified so that it may be prioritised if needed.