### PR TITLE
RDKEMW-7064: Don't call decrypt for fake allocations

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0001-RDKEMW-7064-Dont-decrypt-fake-buffer-is-revoke-has-b.patch
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0001-RDKEMW-7064-Dont-decrypt-fake-buffer-is-revoke-has-b.patch
@@ -1,0 +1,71 @@
+From cab735720b1a12c65ff6aca1c9855ccc6a3ba63c Mon Sep 17 00:00:00 2001
+From: Callum Wilson <callum_wilson@comcast.com>
+Date: Wed, 13 Aug 2025 16:36:05 +0000
+Subject: [PATCH] RDKEMW-7064: Dont decrypt fake buffer is revoke has been
+ called
+
+Reason for change:
+Some platforms cannot allocate secure buffers
+if Essos RM revoke has been called. In this situation
+fake buffers will be allocated which we can't use
+during decryption.
+
+Priority: P2
+
+Risks: Low
+
+Test Procedure:
+- Verify encrypted playback
+- Source switch during encrypted playback
+- Verify app switch during encrypted playback
+
+Signed-off-by: Callum Wilson <callum_wilson@comcast.com>
+---
+ Source/ocdm/adapter/rdk/open_cdm_adapter.cpp | 34 +++++++++++++++-----
+ 1 file changed, 26 insertions(+), 8 deletions(-)
+
+diff --git a/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp b/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp
+index 9d1948f..6b9dec9 100644
+--- a/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp
++++ b/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp
+@@ -446,14 +446,32 @@ OpenCDMError opencdm_gstreamer_session_decrypt_buffer(struct OpenCDMSession* ses
+ 
+                memcpy(encryptedData, mappedData, mappedDataSize);
+ 
+-               GstPerf* ocdm_perf = new GstPerf("opencdm_session_decrypt_v2");
+-               result = opencdm_session_decrypt_v2(session,
+-                                                svpData,
+-                                                dataBlockSize,
+-                                                &sampleInfo,
+-                                                &streamProperties);
+-
+-               delete ocdm_perf;
++               TokenType tokenType = TokenType::InPlace;
++               if (!gst_svp_header_get_field(session->SessionPrivateData(), svpData, SvpHeaderFieldName::Type, (uint32_t*) &tokenType))
++               {
++                  TRACE_L1("Failed to get type from SVP header");
++               }
++
++               const bool isRevokedAllocation = needSecureMemoryPrealloc 
++                                                && tokenType != TokenType::InPlace
++                                                && tokenType != TokenType::Handle
++                                                && tokenType != TokenType::PreAllocatedHandle;
++
++               if (!isRevokedAllocation)
++               {
++                GstPerf* ocdm_perf = new GstPerf("opencdm_session_decrypt_v2");
++                result = opencdm_session_decrypt_v2(session,
++                                                    svpData,
++                                                    dataBlockSize,
++                                                    &sampleInfo,
++                                                    &streamProperties);
++                delete ocdm_perf;
++               }
++               else
++               {
++                    TRACE_L1("Skipping decrypt as resources have been revoked");
++                    result = ERROR_NONE;
++               }
+ 
+                if(result == ERROR_NONE) {
+                   GstPerf* svpTransform_perf3 = new GstPerf("opencdm_svp_transform_subsample");

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
@@ -29,7 +29,8 @@ SRC_URI = "git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=https
            file://r4.4/0001-SecAPI-Re-acquire-sec-handle-after-flush.patch \
            file://r4.4/0001-DELIA-64727-Prealloc-secure-memory-before-decrypt.patch \
            file://r4.4/0001-PowerManagerClient-library-implementation.patch \
-          "
+           file://r4.4/0001-RDKEMW-7064-Dont-decrypt-fake-buffer-is-revoke-has-b.patch \
+           "
 
 # Oct 17, 2023
 SRCREV_wpeframework-clientlibraries = "09a75a85e1263e0520f182dea6dc19c673e070a1"


### PR DESCRIPTION
Reason For Change:
Some platforms do not allow secure buffer allocations after Essos RM Revoke has been called, however, the pipeline may not have been shutdown yet and is still trying to decrypt data. We need to skip decryption in this case.

Priority: P2

Risks: Low

Test Procedure:
- Verify encrypted playback
- Verify Source switch during encrypted playback
- Verify app switch during encrypted playback

Change-Id: I59f16bd77bd0c476ac53d78998327188a7495568

DoD checklist: https://ccp.sys.comcast.net/browse/RDKEMW-7064?focusedId=22978717&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22978717