### PR TITLE
RDKEMW-6446: Update ITextTrack interface to CC HAL (#1393)

### DIFF
--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -15,8 +15,8 @@ SRC_URI += "file://RDKEMW-1007.patch"
 
 
 
-# Tag 1.15.0
-SRCREV_entservices-apis = "c96e5e9c5da04e6a9ab888c7a6b8c4ba0305a713"
+# Tag 1.15.1
+SRCREV_entservices-apis = "2899cceb5be8b754c3f7c87ef613fd90b8fdaf5e"
 
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The next version of ITextTrack supports setting a session up to get its own CC data directly from the video decoder.

Change-Id: I2a4ebe51604384ce2e143e48b39a9811fbd238f9