### PR TITLE
RDKEMW-6934: [RDKEMW-6935] [RDKEMW-6785] [RDKE][Rack][Element/Sky]: WPEFramework crash.

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices Infra plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9adde9d5cb6e9c095d3e3abf0e9500f1"
 
-PV ?= "1.7.3"
+PV ?= "1.7.4"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -17,8 +17,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
           "
 
 
-# Release version - 1.7.3
-SRCREV = "caab6ccf95157eab0162e68b5b941e4568786d09"
+# Release version - 1.7.4
+SRCREV = "86cbc09681822c2c56b8c593da963c6120c20404"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change:
WPEFramework crashwith signature WPEFramework::Plugin::USBDeviceImplementation::libUSBEventsHandlingThread with fingerprint 14820164 during Reboot testing. [RDKMW][RTK-XIONE] WPEFramework crash Observed while Launching and Playing XUMO Play.

Test Procedure:
Reboot testing needs to do. No. of Reboots: Atleast 50 Reboots. Refer RDKEMW-6934, RDKEMW-6935, RDKEMW-6785
Risks: High
Priority: P1