### PR TITLE
RDKEMW-4840: Custom build for OCDM restart

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -73,6 +73,7 @@ PACKAGECONFIG ?= " monitor \
     ${@bb.utils.contains('DISTRO_FEATURES', 'rdkshell',             'rdkshell', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'rdkshell enable_rialto', 'rdkshellrialto', '', d)} \
     ${@bb.utils.contains_any('DISTRO_FEATURES', '${DISTRO_FEATURES_CHECK}', ' messagecontrol ', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opencdm', 'opencdmi', '', d)} \
 "
 
 # TODO: As advised, 'ocicointainer' plugin has been modified to build unconditionally. It will be revisited in the upcoming sprint to control it via DISTRO_FEATURES."
@@ -129,6 +130,7 @@ PACKAGECONFIG[packagemanager]       = "-DPLUGIN_PACKAGE_MANAGER=ON -DLIB_PACKAGE
 PACKAGECONFIG[lifecyclemanager]     = "-DPLUGIN_LIFECYCLE_MANAGER=ON,-DPLUGIN_LIFECYCLE_MANAGER=OFF,websocketpp entservices-apis,entservices-apis"
 PACKAGECONFIG[storagemanager]       = "-DPLUGIN_STORAGE_MANAGER=ON,-DPLUGIN_STORAGE_MANAGER=OFF,entservices-apis,entservices-apis"
 PACKAGECONFIG[appmanager]           = "-DPLUGIN_APPMANAGER=ON,-DPLUGIN_APPMANAGER=OFF,entservices-apis,entservices-apis"
+PACKAGECONFIG[opencdmi]             = "-DPLUGIN_OPENCDMI=ON"
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Reason for change: OCDM Plugin Not Restarting After Crash 
Test Procedure: Check weather after crash OCDM plugin should restart  
Risks: Low

Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com