### PR TITLE
RDKEMW-6225 NetworkManager Plugin Release - 0.25.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.23.0"
+PV = "0.25.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Jul 30, 2025
-SRCREV = "562ece896f27a6a93b309b1663e8316b82b401e4"
+# Aug 28, 2025
+SRCREV = "74dc46659b8f9c6c9fb3a79f8da731b6b5aee27b"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.25.0 with following Bug fixes

- Implemented SetHostname method which can send device's hostname over DHCP explicitly
- Implemented L1/L2 for netsrvmgr (RDK), libnm backends
- Clamped the WIFI Noise value to be within 0 dBm to -96 dBm
- Handled Plugin Termination sequence to stop the monitoring thread before exit
- Handled out-of-process plugin configuration as string
- Fixed Router Discovery to handle dual interface
- Fixed Internet Connectivity Monitoring to not to poll unless requested
- Addressed coverity reported issue