### PR TITLE
RDKEMW-3387: meta-rdk-video - fixed wpeframework-ocdm.service failed …

### DIFF
--- a/recipes-extended/thunderstartupservices/thunderstartupservices.bb
+++ b/recipes-extended/thunderstartupservices/thunderstartupservices.bb
@@ -60,6 +60,7 @@ CONTROL_FILES = "\
     wpeframework-services.path \
     wpeframework-services.target \
     wpeframework-provisioning-ready.path \
+    wpeframework-provisioning-ready.target \
     "
 
 do_install() {


### PR DESCRIPTION
…state

Reason for change:
- OCDM fails w/o DRM (fail fast policy)
- wpeframework-ocdm.service starts w/o DRM because it is a systemd service which is not aware when device is provisioned
- This makes OCDM fail Resolution: New systemd unit wpeframework-provisioning-ready.path allows OCDM to start timely

Test Procedure: described in the ticket
Implements: code changes in DeviceProvisioning and Thunder Startup Services
Risks: No
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending