### PR TITLE
RDKEMW-5842 - NetworkManager Plugin - Coverity Improvements

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.25.0"
+PV = "1.0.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Aug 28, 2025
-SRCREV = "74dc46659b8f9c6c9fb3a79f8da731b6b5aee27b"
+# Aug 29, 2025
+SRCREV = "7abe7ab0484abda2d372bd24fbcc6df0b2c08708"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 1.0.0 with following Bug fixes
- Implemented additional L1/L2 for libnm backends
- Addressed Coverity issues in Connectivity Monitoring Thread
- Marking official production release.