### PR TITLE
RDKEMW-7452: Add support for Matter and Barton recipes

### DIFF
--- a/recipes-iot/barton-core/barton_%.bbappend
+++ b/recipes-iot/barton-core/barton_%.bbappend
@@ -1,0 +1,19 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Skip unless the distro advertises "ENABLE_MATTER_BARTON"
+inherit features_check
+REQUIRED_DISTRO_FEATURES = "ENABLE_MATTER_BARTON"
+
+# Add libxml2 to DEPENDS
+DEPENDS:append = "libxml2 jsoncpp"
+
+# Remove otbr-agent from DEPENDS
+DEPENDS:remove = "otbr-agent"
+
+# Add the patch to SRC_URI
+SRC_URI += "file://add-so-version.patch"
+
+EXTRA_OECMAKE += "\
+    -DBCORE_ZIGBEE=OFF \
+    -DBCORE_THREAD=OFF \
+"

--- a/recipes-iot/barton-core/files/add-so-version.patch
+++ b/recipes-iot/barton-core/files/add-so-version.patch
@@ -1,0 +1,15 @@
+diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index 45f1ec2..8bb9d14 100644
+--- a/core/CMakeLists.txt
++++ b/core/CMakeLists.txt
+@@ -212,6 +212,10 @@ target_include_directories(BartonCoreStatic PRIVATE
+                             )
+ 
+ add_library(BartonCore SHARED $<TARGET_OBJECTS:bCoreObject>)
++set_target_properties(BartonCore PROPERTIES
++    VERSION 1.0
++    SOVERSION 1
++)
+ target_link_libraries(BartonCore ${bCoreLinkLibraries})
+ target_include_directories(BartonCore PRIVATE
+                             ${BARTON_PRIVATE_INCLUDES}

--- a/recipes-iot/barton-matter/barton-matter_%.bbappend
+++ b/recipes-iot/barton-matter/barton-matter_%.bbappend
@@ -1,0 +1,21 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/../../../meta-rdk-iot/recipes-matter/barton-matter-example/files:"
+
+# Skip unless the distro advertises "ENABLE_MATTER_BARTON"
+inherit features_check
+REQUIRED_DISTRO_FEATURES = "ENABLE_MATTER_BARTON"
+
+SRC_URI += " \
+    file://barton.zap \
+    file://zzz_generated.tar.gz \
+"
+
+MATTER_ZAP_FILE = "${WORKDIR}/barton.zap"
+
+# Adding the zzz_generated tarball to the SRC_URI will unpack it into WORKDIR
+MATTER_ZZZ_GENERATED = "${WORKDIR}/zzz_generated"
+
+MATTER_CONF_DIR = "/var/lib/my-product"
+
+do_install:append() {
+    cp -r "${S}/third_party/jsoncpp/repo/include/"* "${D}${includedir}/matter/"
+}


### PR DESCRIPTION
Enable Matter and Barton recipes with DISTRO-based conditional build control.