### PR TITLE
Rebase

### DIFF
--- a/recipes-extended/thunderstartupservices/thunderstartupservices.bb
+++ b/recipes-extended/thunderstartupservices/thunderstartupservices.bb
@@ -88,7 +88,9 @@ do_install() {
 }
 
 do_install:append() {
-    SERVICE="${D}${systemd_system_unitdir}/wpeframework-displaysettings.service"
+    SERVICE_DIR="${D}${systemd_system_unitdir}"
+
+    SERVICE="${SERVICE_DIR}/wpeframework-displaysettings.service"
 
     if [ -f "$SERVICE" ]; then
         # Insert the line before [Service], only if not already present
@@ -96,6 +98,44 @@ do_install:append() {
             sed -i '/^\[Service\]/i ConditionPathExists=/tmp/wpeframeworkstarted' "$SERVICE"
         fi
     fi
+
+    # IPControl service to add securemount dependencies
+    IP_SERVICE="${SERVICE_DIR}/wpeframework-ipcontrol.service"
+    if [ -f "$IP_SERVICE" ]; then
+        # Append securemount.service to the existing After= line
+        sed -i '/^After=/ s/$/ securemount.service/' "$IP_SERVICE"
+
+        # Add RequiresMountsFor=/opt/secure immediately after the After= line
+        sed -i '/^After=/a RequiresMountsFor=/opt/secure' "$IP_SERVICE"
+    fi
+
+
+    # Ensure all services are in proper Unix LF format
+    find "$SERVICE_DIR" -type f -name "*.service" -exec sed -i 's/\r$//' {} +
+
+    for x in ${THUNDER_STARTUP_SERVICES}; do
+        SERVICE_FILE="${SERVICE_DIR}/${x}"
+
+        # --- Normalize Description ---
+        # Converts: "Description=WPEFramework SystemMode Initialiser"
+        # To:      "Description=WPE SystemMode"
+        sed -i 's/^Description=WPEFramework \(.*\) Initialiser$/Description=WPE \1/' "$SERVICE_FILE"
+
+        if grep -q '^ExecStart=.*PluginActivator' "$SERVICE_FILE"; then
+            CALLSIGN=$(sed -n -E 's/.*PluginActivator.*[[:space:]]+([A-Za-z0-9_.-]+)$/\1/p' "$SERVICE_FILE")
+
+            if [ -n "$CALLSIGN" ]; then
+                if ! grep -q "^ExecStop=/usr/bin/PluginActivator.*$CALLSIGN" "$SERVICE_FILE"; then
+                    if grep -q '^ExecStartPost=' "$SERVICE_FILE"; then
+                        sed -i "/^ExecStartPost=/a ExecStop=/usr/bin/PluginActivator -r 5 -x $CALLSIGN" "$SERVICE_FILE"
+                    else
+                        sed -i "/^ExecStart=.*PluginActivator/a ExecStop=/usr/bin/PluginActivator -r 5 -x $CALLSIGN" "$SERVICE_FILE"
+                    fi
+                fi
+            fi
+        fi
+
+    done
 }
 
 FILES:${PN} += "${systemd_system_unitdir} ${sysconfdir}/systemd/system"

--- a/recipes-extended/wpe-framework/wpeframework/r4.4/Integrate_deactivate_function_PluginActivator.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/Integrate_deactivate_function_PluginActivator.patch
@@ -1,0 +1,167 @@
+From: Thamim Razith <tabbas651@cable.comcast.com>
+Date: Thu, 14 Aug 2025 11:58:11 +0000
+Subject: [PATCH] Integrated deactivate function in PLuginactivator
+Upstream-Status: Pending
+Signed-off-by: Thamim razith Abbas ali <tabbas651@cable.comcast.com>
+------------------------------------------------------------------
+Index: git/Utils/PluginActivator/source/COMRPCStarter.h
+===================================================================
+--- git.orig/Utils/PluginActivator/source/COMRPCStarter.h
++++ git/Utils/PluginActivator/source/COMRPCStarter.h
+@@ -35,6 +35,7 @@ public:
+     ~COMRPCStarter() override;
+
+     bool activatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs) override;
++    bool deactivatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs) override;
+     
+ private:
+     using ControllerConnector = RPC::SmartControllerInterfaceType<Exchange::Controller::ILifeTime>;
+@@ -42,4 +43,4 @@ private:
+ private:
+     ControllerConnector _connector;
+     const string _pluginName;
+-};
+\ No newline at end of file
++};
+Index: git/Utils/PluginActivator/source/IPluginStarter.h
+===================================================================
+--- git.orig/Utils/PluginActivator/source/IPluginStarter.h
++++ git/Utils/PluginActivator/source/IPluginStarter.h
+@@ -40,4 +40,5 @@ public:
+      * @param[in]   retryDelayMs        Amount of time to wait after a failed activation before retrying again
+      */
+     virtual bool activatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs) = 0;
+-};
+\ No newline at end of file
++    virtual bool deactivatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs) = 0;
++};
+Index: git/Utils/PluginActivator/source/COMRPCStarter.cpp
+===================================================================
+--- git.orig/Utils/PluginActivator/source/COMRPCStarter.cpp
++++ git/Utils/PluginActivator/source/COMRPCStarter.cpp
+@@ -108,3 +108,57 @@ bool COMRPCStarter::activatePlugin(const uint8_t maxRetries, const uint16_t retr
+
+     return success;
+ }
++
++bool COMRPCStarter::deactivatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs)
++{
++    bool success = false;
++    int currentRetry = 1;
++
++    while (!success && currentRetry <= maxRetries) {
++        LOG_INF(_pluginName.c_str(), "Attempting to deactivate plugin - attempt %d/%d", currentRetry, maxRetries);
++
++        auto start = Core::Time::Now();
++
++        if (_connector.IsOperational() == false) {
++            uint32_t result = _connector.Open(RPC::CommunicationTimeOut, ControllerConnector::Connector());
++            if(result != Core::ERROR_NONE) {
++                LOG_ERROR(_pluginName.c_str(), "Failed to get controller interface, error %u (%s)", result, Core::ErrorToString(result));
++            }
++        }
++
++        Exchange::Controller::ILifeTime* lifetime = _connector.Interface();
++
++        if (lifetime == nullptr) {
++            LOG_ERROR(_pluginName.c_str(), "Failed to open ILifeTime interface" );
++            currentRetry++;
++
++            _connector.Close(RPC::CommunicationTimeOut);
++
++            std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
++        } else {
++            uint32_t result = lifetime->Deactivate(_pluginName.c_str());
++
++            auto duration = Core::Time::Now().Sub(start.MilliSeconds());
++
++            if (result != Core::ERROR_NONE) {
++                LOG_ERROR(_pluginName.c_str(), "Failed to deactivate plugin with error %u (%s) after %dms", result, Core::ErrorToString(result), duration.MilliSeconds());
++                currentRetry++;
++                std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
++            } else {
++                LOG_INF(_pluginName.c_str(), "Successfully deactivated plugin after %dms", duration.MilliSeconds());
++                success = true;
++            }
++            lifetime->Release();
++        }
++    }
++
++    if (!success) {
++        LOG_ERROR(_pluginName.c_str(), "Max retries hit - giving up deactivating the plugin");
++    }
++
++    if (_connector.IsOperational() == true) {
++        _connector.Close(RPC::CommunicationTimeOut);
++    }
++
++    return success;
++}
+Index: git/Utils/PluginActivator/source/main.cpp
+===================================================================
+--- git.orig/Utils/PluginActivator/source/main.cpp
++++ git/Utils/PluginActivator/source/main.cpp
+@@ -26,6 +26,8 @@ static int gRetryCount = 100;
+ static int gRetryDelayMs = 500;
+ static string gPluginName;
+
++static bool gDeactivate = false;
++
+ /**
+  * @brief Display a help message for the tool
+  */
+@@ -36,6 +38,7 @@ static void displayUsage()
+     printf("    -h, --help          Print this help and exit\n");
+     printf("    -r, --retries       Maximum amount of retries to attempt to start the plugin before giving up\n");
+     printf("    -d, --delay         Delay (in ms) between each attempt to start the plugin if it fails\n");
++    printf("    -x, --deactivate    Deactivate the plugin instead of activating\n");
+     printf("\n");
+     printf("    [callsign]          Callsign of the plugin to activate (Required)\n");
+ }
+@@ -57,6 +60,7 @@ static void parseArgs(const int argc, char** argv)
+         { "help", no_argument, nullptr, (int)'h' },
+         { "retries", required_argument, nullptr, (int)'r' },
+         { "delay", required_argument, nullptr, (int)'d' },
++        { "deactivate", no_argument, nullptr, (int)'x' },
+         { nullptr, 0, nullptr, 0 }
+     };
+
+@@ -65,7 +69,7 @@ static void parseArgs(const int argc, char** argv)
+     int option;
+     int longindex;
+
+-    while ((option = getopt_long(argc, argv, "hr:d:", longopts, &longindex)) != -1) {
++    while ((option = getopt_long(argc, argv, "hr:d:x", longopts, &longindex)) != -1) {
+         switch (option) {
+         case 'h':
+             displayUsage();
+@@ -85,6 +89,9 @@ static void parseArgs(const int argc, char** argv)
+                 exit(EXIT_FAILURE);
+             }
+             break;
++        case 'x':
++            gDeactivate = true;
++            break;
+         case '?':
+             if (optopt == 'c')
+                 fprintf(stderr, "Warning: Option -%c requires an argument.\n", optopt);
+@@ -122,11 +129,16 @@ int main(int argc, char* argv[])
+     // in the future
+     bool success;
+     std::unique_ptr<IPluginStarter> starter(new COMRPCStarter(gPluginName));
+-    success = starter->activatePlugin(gRetryCount, gRetryDelayMs);
++    // Explicitly check for deactivate or activate
++    if (gDeactivate) {
++        success = starter->deactivatePlugin(gRetryCount, gRetryDelayMs);
++    } else {
++        success = starter->activatePlugin(gRetryCount, gRetryDelayMs);
++    }
+
+     // Destruct the COM-RPC starter so it cleans up after itself before we dispose WPEFramework singletons
+     starter.reset();
+     Core::Singleton::Dispose();
+
+     return success ? EXIT_SUCCESS : EXIT_FAILURE;
+-}
+\ No newline at end of file
++}

--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=wpeframework-Thunder RPC version-R4.4.3
 Wants= local-fs.target
-After= local-fs.target
+After= local-fs.target securemount.service
+RequiresMountsFor=/opt/secure
 
 [Service]
 Type=notify

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -46,6 +46,7 @@ SRC_URI += "file://wpeframework-init \
            file://r4.4/Update-Trace-Level-Logging-Logic.patch \
            file://r4.4/Activating_plugins_Logs_COMRPC.patch \
            file://r4.4/Removed_Autostart_Check_From_WPEFramework.patch \
+           file://r4.4/Integrate_deactivate_function_PluginActivator.patch \
            "
 
 SRC_URI += "file://r4.4/PR-1369-Wait-for-Open-in-Communication-Channel.patch \
@@ -75,7 +76,7 @@ WPEFRAMEWORK_SYSTEM_PREFIX = "OE"
 WPEFRAMEWORK_PORT = "9998"
 WPEFRAMEWORK_BINDING = "127.0.0.1"
 WPEFRAMEWORK_IDLE_TIME = "0"
-WPEFRAMEWORK_THREADPOOL_COUNT ?= "8"
+WPEFRAMEWORK_THREADPOOL_COUNT ?= "16"
 WPEFRAMEWORK_EXIT_REASONS ?= "WatchdogExpired"
 
 


### PR DESCRIPTION
…TIVATE  & added via ExecStop in ThunderStartupServices (#1404)

* RDKEMW-6542: Update the PluginActivator to support DEACTIVATE

Reason for change:  Added the Deactivate support in the PluginActivator
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1

* added the usr/bin/PluginActivator -x logic for all services to appened the chnages to all thunder-startup services

* Reduce stop timeout from default 90s to 30s between SIGTERM and SIGKILL it helps to  improve the thunder shutdown time

* Added back the Secure mount dependency for persistent plugin activation

* updated the grep check command in install_append

* Added -x support in the wpeframework patch

* Removed the TimeoutStopSec changes

* Updated the ThreadPoolCount to 16 insteaded of 8 to increase the thunder bootup perforamance

* Updated the  thunderstartupservices for retires count to 5 for all services and also added securemount depdendency to wpeframework-ipcontrol.service

* Added the changes for Normalized the Description in the thunderstartup systemd services