### PR TITLE
RDKEMW-7974, RDKEMW-7975 - Porting develop branch changes to support

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.20.1"
+PV = "0.20.2"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=support/0.20.0"
 
-# Aug 29, 2025
-SRCREV = "ba1c3094229e2c8b72f4d4247400e7552fb0fc39"
+# Sep 09, 2025
+SRCREV = "6cb0e3d03bb9b09b114c443fb37ba738931281b1"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "

--- a/recipes-extended/wpe-framework/thunderhangrecovery/thunderHangRecovery.cpp
+++ b/recipes-extended/wpe-framework/thunderhangrecovery/thunderHangRecovery.cpp
@@ -30,13 +30,13 @@
 
 #define NUM_ELEMENTS                  3
 #define PROCESS_NAME                  "WPEFramework"
-#define CONFIG_FILE                   "/opt/thunderHangDetector/thunderHangDetector.json"
+#define CONFIG_FILE                   "/opt/thunderHangRecovery/thunderHangRecovery.json"
 #define THUNDER_START_WAIT_TIME       180 /* 3 minutes wait time for thunder to start before monitoring it */
 
 const char* HANG_DETECTOR_ENABLE = "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Thunder.HangDetector.Enable";
 const char* HANG_DETECTOR_COREFILE_ENABLE = "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Thunder.HangDetector.CoreFile.Enable";
 const char* HANG_DETECTOR_POLLING_COUNT = "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Thunder.HangDetector.Polling.Count";
-std::atomic<bool> hangDetetectorEnable{true};
+std::atomic<bool> hangDetetectorEnable{false};
 std::atomic<bool> coreFileEnable{false};
 std::atomic<unsigned int> pollingCount{5};
 cJSON* json = nullptr;
@@ -105,8 +105,10 @@ static void writeJsonToFile()
 {
     if (json == nullptr)
     {
-        LOG_MSG("JSON object is null");
-        return;
+        json = cJSON_CreateObject();
+        cJSON_AddBoolToObject(json, "hangDetectorEnable", hangDetetectorEnable);
+        cJSON_AddBoolToObject(json, "coreFileEnable", coreFileEnable);
+        cJSON_AddNumberToObject(json, "pollingCount", pollingCount);
     }
 
     char* jsonString = cJSON_Print(json);
@@ -460,7 +462,6 @@ int main() {
     std::string jsonData;
 
     struct curl_slist *headers = nullptr;
-    headers = curl_slist_append(headers, "Content-Type: application/json");
 
     unsigned int failureCount = 0;
     unsigned int successCount = 0;
@@ -471,28 +472,9 @@ int main() {
 
     int ret = RBUS_ERROR_SUCCESS;
 
-    // Open and read the JSON file
     std::ifstream file(CONFIG_FILE);
-    if (!file.is_open())
+    if (!file.fail())
     {
-        LOG_MSG("Unable to open file: %s", CONFIG_FILE);
-        json = cJSON_CreateObject();
-        cJSON_AddBoolToObject(json, "hangDetectorEnable", hangDetetectorEnable);
-        cJSON_AddBoolToObject(json, "coreFileEnable", coreFileEnable);
-        cJSON_AddNumberToObject(json, "pollingCount", pollingCount);
-
-        char *jsonString = cJSON_Print(json);
-        if (jsonString == nullptr) {
-            LOG_MSG("Failed to print JSON string");
-            cJSON_Delete(json);
-            json = nullptr;
-        }
-        cJSON_free(jsonString);
-        writeJsonToFile();
-    }
-    else
-    {
-        // Read entire file content into a string
         std::string jsonContent((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
         file.close();
 
@@ -517,7 +499,6 @@ int main() {
                 pollingCount = pollingCountValue->valueint;
         }
     }
-
     ret = rbus_open(&rbus_handle, "thunderHangDetector");
     if(ret != RBUS_ERROR_SUCCESS)
         LOG_MSG("rbus open failed with error code %d", ret);
@@ -532,52 +513,64 @@ int main() {
     ret = rbus_regDataElements(rbus_handle, NUM_ELEMENTS, dataElements);
 
     sleep(THUNDER_START_WAIT_TIME);
-    pid = getPID();
-    while (true) {
-        std::ostringstream jsonStream;
-        jsonStream << R"json({"jsonrpc": "2.0", "id": )json" << iterationCount << R"json(, "method": "Controller.1.status"})json";
-        jsonData = jsonStream.str();
-        if(isRunning(pid))
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+    while (true)
+    {
+        pid = getPID();
+        if(hangDetetectorEnable)
         {
-            CurlObject curlObj(url, jsonData, headers);
-            long httpCode = curlObj.gethttpcode();
+            std::ostringstream jsonStream;
+            jsonStream << R"json({"jsonrpc": "2.0", "id": )json" << iterationCount << R"json(, "method": "Controller.1.version"})json";
+            jsonData = jsonStream.str();
+            if(isRunning(pid))
+            {
+                CurlObject curlObj(url, jsonData, headers);
+                long httpCode = curlObj.gethttpcode();
 
-            if (httpCode != 200) {
-                failureCount++;
-                LOG_MSG("External JSONRPC failed for %d retry", failureCount);
-                timer = 5;
-                if (failureCount >= pollingCount) {
-                    LOG_MSG("Number of external JSONRPC request successfully executed before thunder hang: %d ", successCount);
-                    LOG_MSG("Thunder is not responding to the %d consecutive external JSONRPC request", pollingCount.load());
-                    if(hangDetetectorEnable)
-                    {
-                        killPID(pid);
+                if (httpCode != 200) {
+                    failureCount++;
+                    LOG_MSG("External JSONRPC failed for %d retry", failureCount);
+                    timer = 5;
+                    if (failureCount >= pollingCount) {
+                        LOG_MSG("Number of external JSONRPC request successfully executed before thunder hang: %d ", successCount);
+                        LOG_MSG("Thunder is not responding to the %d consecutive external JSONRPC request", pollingCount.load());
+                        if(hangDetetectorEnable)
+                        {
+                            killPID(pid);
+                        }
+                        else
+                        {
+                            LOG_MSG("THUNDER_HANG_DETECTED state: MONITORING");
+                        }
+                        failureCount = 0;
+                        successCount = 0;
                     }
-                    else
-                    {
-                        LOG_MSG("THUNDER_HANG_DETECTED state: MONITORING");
-                    }
+                } else {
+                    if(failureCount < pollingCount && failureCount != 0)
+                        LOG_MSG("External JSONRPC recovered after %d retry", failureCount);
+                    timer = 30;
                     failureCount = 0;
-                    successCount = 0;
+                    successCount++;
                 }
-            } else {
-                if(failureCount < pollingCount && failureCount != 0)
-                    LOG_MSG("External JSONRPC recovered after %d retry", failureCount);
-                timer = 30;
-                failureCount = 0;
-                successCount++;
             }
+            else
+            {
+                LOG_MSG("%s is not running", PROCESS_NAME);
+                sleep(THUNDER_START_WAIT_TIME);
+                pid = getPID();
+            }
+            iterationCount++;
+            sleep(timer);
         }
         else
         {
-            LOG_MSG("%s is not running", PROCESS_NAME);
             sleep(THUNDER_START_WAIT_TIME);
-            pid = getPID();
         }
-        iterationCount++;
-        sleep(timer);
     }
-    curl_slist_free_all(headers);
+    if(headers)
+    {
+        curl_slist_free_all(headers);
+    }
 
     return 0;
 }

--- a/recipes-extended/wpe-framework/thunderhangrecovery/thunderHangRecovery.service
+++ b/recipes-extended/wpe-framework/thunderhangrecovery/thunderHangRecovery.service
@@ -4,7 +4,8 @@ After=wpeframework.service
 Requires=wpeframework.service
 
 [Service]
-ExecStartPre=/bin/sh -c 'mkdir -p /opt/thunderHangDetector'
+ExecStartPre=/bin/rm -rf /opt/thunderHangDetector
+ExecStartPre=/bin/mkdir -p /opt/thunderHangRecovery
 ExecStart=/usr/bin/thunderHangRecovery
 Type=simple
 Restart=always


### PR DESCRIPTION
RDKEMW-7975 - Optimize the Internet Connectivity Monitoring approach port to support branch
Reason for change: Added device model and version details to the user agent of curl request and enabling the continuous monitoring only when the internet state is other fully connected
Test Procedure: check the tcpdump

RDKEMW-7974 - Improve thunder hang recovery process porting to support branch
Reason for change: Modified the thunder hang recovery with below 
- Only when the thunderHangRecovery is enabled, polling will be started for monitoring wpeframework otherwise no action will be taken 
- Create the json file to store the RFC value only when the RFC set is called when the device booted initially without any json file 
- Removed the old file and created new file to store the RFC value 
Test Procedure: Test and verify the monitoring is done or not 
Risks: Medium
Priority: P1