### PR TITLE
RDKEMW-6934: [RDKEMW-6935] [RDKEMW-6785] [RDKE][Rack][Element/Sky]: W…

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices Infra plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9adde9d5cb6e9c095d3e3abf0e9500f1"
 
-PV ?= "1.4.4.3"
+PV ?= "1.4.4.4"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -16,8 +16,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDK-41681-PR4013.patch \
           "
 
-# Release version - 1.4.4.3
-SRCREV = "a8477489f24692249ee6eee9fc1f7015106d10be"
+# Release version - 1.4.4.4
+SRCREV = "fe76f86df8fa62137c9c3438d6518d2746d5fc99"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
…PEFramework crash.

Reason for change:
WPEFramework crashwith signature WPEFramework::Plugin::USBDeviceImplementation::libUSBEventsHandlingThread with fingerprint 14820164 during Reboot testing. [RDKMW][RTK-XIONE] WPEFramework crash Observed while Launching and Playing XUMO Play.

Test Procedure:
Reboot testing needs to do. No. of Reboots: Atleast 50 Reboots. Refer RDKEMW-6934, RDKEMW-6935, RDKEMW-6785 Risks: High
Priority: P1