### PR TITLE
RDKEMW-8302 - NetworkManager Plugin Release - 1.3.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "1.0.0"
+PV = "1.3.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Aug 29, 2025
-SRCREV = "7abe7ab0484abda2d372bd24fbcc6df0b2c08708"
+# Sep 17, 2025
+SRCREV = "9709dd5f5ed714bf6f6f41e0c368dcd804b16e71"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 1.3.0 with following Bug fixes
- Implemented NetworkManagerProxy library which can help Thunder to Create COM-RPC connection to Out-Of-Process plugin
- Implemented Internet Connectivity Monitoring for specific to Primary Interface.
- Updated to not to post onInternetStatusChanged event when secondary interface is disturbed.