### PR TITLE
RDKEMW-8425: Runtime HDR & DV WebKit settings for 2.38.8

### DIFF
--- a/recipes-extended/wpe-webkit/files/2.38.8/1448_Added-API-to-get-and-set-screen-supports-HDR-setting.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/1448_Added-API-to-get-and-set-screen-supports-HDR-setting.patch
@@ -1,0 +1,186 @@
+From ae22d69a316c2b533285592d3b31a2ed45e5dae2 Mon Sep 17 00:00:00 2001
+From: Przemyslaw Gorszkowski <pgorszkowski@igalia.com>
+Date: Wed, 22 Jan 2025 10:25:09 +0100
+Subject: [PATCH] Added API to get and set screen-supports-HDR setting
+
+---
+ .../Scripts/Preferences/WebPreferences.yaml   | 10 ++++
+ Source/WebCore/platform/PlatformScreen.h      |  2 +-
+ .../platform/wpe/PlatformScreenWPE.cpp        |  9 +++
+ .../UIProcess/API/glib/WebKitSettings.cpp     | 57 +++++++++++++++++++
+ .../WebKit/UIProcess/API/wpe/WebKitSettings.h |  7 +++
+ 5 files changed, 84 insertions(+), 1 deletion(-)
+
+diff --git a/Source/WTF/Scripts/Preferences/WebPreferences.yaml b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+index 18a5d3eb93c6..18e7d6277005 100644
+--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
++++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+@@ -1918,6 +1918,16 @@ SansSerifFontFamily:
+     WebCore:
+       default: '""'
+ 
++ScreenSupportsHDR:
++  type: bool
++  defaultValue:
++    WebKitLegacy:
++      default: false
++    WebKit:
++      default: false
++    WebCore:
++      default: false
++
+ ScrollAnimatorEnabled:
+   type: bool
+   defaultValue:
+diff --git a/Source/WebCore/platform/PlatformScreen.h b/Source/WebCore/platform/PlatformScreen.h
+index 44799e0b2a93..177bb197676a 100644
+--- a/Source/WebCore/platform/PlatformScreen.h
++++ b/Source/WebCore/platform/PlatformScreen.h
+@@ -95,7 +95,7 @@ WEBCORE_EXPORT DynamicRangeMode preferredDynamicRangeMode(Widget* = nullptr);
+ constexpr DynamicRangeMode preferredDynamicRangeMode(Widget* = nullptr) { return DynamicRangeMode::Standard; }
+ #endif
+ 
+-#if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
++#if PLATFORM(MAC) || PLATFORM(IOS_FAMILY) || PLATFORM(WPE)
+ WEBCORE_EXPORT bool screenSupportsHighDynamicRange(Widget* = nullptr);
+ #else
+ constexpr bool screenSupportsHighDynamicRange(Widget* = nullptr) { return false; }
+diff --git a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+index bbdd1ce76241..8d8579be437a 100644
+--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
++++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+@@ -28,6 +28,8 @@
+ 
+ #include "DestinationColorSpace.h"
+ #include "FloatRect.h"
++#include "Frame.h"
++#include "FrameView.h"
+ #include "NotImplemented.h"
+ #include "Widget.h"
+ 
+@@ -104,4 +106,11 @@ bool screenIsTouchPrimaryInputDevice()
+ }
+ #endif
+ 
++bool screenSupportsHighDynamicRange(Widget* widget)
++{
++    if(!widget || !widget->root())
++        return false;
++
++    return widget->root()->frame().settings().screenSupportsHDR();
++}
+ } // namespace WebCore
+diff --git a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+index 7b5eda70b39d..937b2be5f9a6 100644
+--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
++++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+@@ -188,6 +188,7 @@ enum {
+     PROP_ENABLE_SERVICE_WORKER,
+     PROP_ENABLE_ICE_CANDIDATE_FILTERING,
+     PROP_WEBRTC_UDP_PORTS_RANGE,
++    PROP_SCREEN_SUPPORTS_HDR,
+     N_PROPERTIES,
+ };
+ 
+@@ -448,6 +449,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
+     case PROP_WEBRTC_UDP_PORTS_RANGE:
+         webkit_settings_set_webrtc_udp_ports_range(settings, g_value_get_string(value));
+         break;
++    case PROP_SCREEN_SUPPORTS_HDR:
++        webkit_settings_set_screen_supports_hdr(settings, g_value_get_boolean(value));
++        break;
+     default:
+         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+         break;
+@@ -679,6 +683,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
+     case PROP_WEBRTC_UDP_PORTS_RANGE:
+         g_value_set_string(value, webkit_settings_get_webrtc_udp_ports_range(settings));
+         break;
++    case PROP_SCREEN_SUPPORTS_HDR:
++        g_value_set_boolean(value, webkit_settings_get_screen_supports_hdr(settings));
++        break;
+     default:
+         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+         break;
+@@ -1807,6 +1814,19 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
+         nullptr, // A null string forces the default value.
+         readWriteConstructParamFlags);
+ 
++     /**
++     * WebKitSettings:screen-supports-hdr:
++     *
++     * Screen supports HDR.
++     *
++     */
++    sObjProperties[PROP_SCREEN_SUPPORTS_HDR] = g_param_spec_boolean(
++        "screen-supports-hdr",
++        _("Screen supports HDR"),
++        _("Does screen support HDR."),
++        FALSE,
++        readWriteConstructParamFlags);
++
+     g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+ }
+ 
+@@ -4547,3 +4567,40 @@ webkit_settings_set_webrtc_udp_ports_range(WebKitSettings* settings, const gchar
+     UNUSED_PARAM(udpPortsRange);
+ #endif
+ }
++
++/**
++ * webkit_settings_get_screen_supports_hdr:
++ * @settings: a #WebKitSettings
++ *
++ * Get the [property@Settings:screen-supports-hdr] property.
++ *
++ * Returns: Screen supports HDR, or FALSE if un-set.
++ *
++ */
++gboolean
++webkit_settings_get_screen_supports_hdr(WebKitSettings* settings)
++{
++    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
++    return settings->priv->preferences->screenSupportsHDR();
++}
++
++/**
++ * webkit_settings_set_screen_supports_hdr:
++ * @settings: a #WebKitSettings
++ * @screenSupportsHDR: Value to be set
++ *
++ * Set the [property@Settings:screen-supports-hdr] property.
++ *
++ */
++void
++webkit_settings_set_screen_supports_hdr(WebKitSettings* settings, gboolean screenSupportsHDR)
++{
++    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
++    WebKitSettingsPrivate* priv = settings->priv;
++    bool currentValue = priv->preferences->screenSupportsHDR();
++    if (currentValue == screenSupportsHDR)
++        return;
++
++    priv->preferences->setScreenSupportsHDR(screenSupportsHDR);
++    g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_SCREEN_SUPPORTS_HDR]);
++}
+diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h b/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
+index 3549908f103d..847d95318620 100644
+--- a/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
++++ b/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
+@@ -547,6 +547,13 @@ WEBKIT_API void
+ webkit_settings_set_webrtc_udp_ports_range                     (WebKitSettings *settings,
+                                                                 const gchar    *udp_port_range);
+ 
++WEBKIT_API gboolean
++webkit_settings_get_screen_supports_hdr                        (WebKitSettings* settings);
++
++WEBKIT_API void
++webkit_settings_set_screen_supports_hdr                        (WebKitSettings* settings,
++                                                                gboolean screenSupportsHDR);
++
+ G_END_DECLS
+ 
+ #endif /* WebKitSettings_h */
+-- 
+2.48.1
+

--- a/recipes-extended/wpe-webkit/files/2.38.8/1463_GStreamer-support-the-eotf-additional-MIME-type.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/1463_GStreamer-support-the-eotf-additional-MIME-type.patch
@@ -1,0 +1,47 @@
+From b5cf513170734642190775ec0c4bad02068b809c Mon Sep 17 00:00:00 2001
+From: Przemyslaw Gorszkowski <pgorszkowski@igalia.com>
+Date: Fri, 14 Feb 2025 02:06:14 -0800
+Subject: [PATCH] [GTK][WPE][GStreamer] support the 'eotf' additional MIME type
+ parameter by isSupportedType https://bugs.webkit.org/show_bug.cgi?id=287560
+
+Reviewed by Philippe Normand.
+
+MediaSource.isSupportedType method must support the 'eotf' additional MIME type parameter and support the following values:
+* 'bt709', indicating ITU-R BT.1886 support
+* 'smpte2084', to indicate SMPTE 2084 EOTF support
+* 'arib-std-b67', to indicate ARIB STD-B67 support
+
+to be compliant with "YouTube TV HTML5 Technical Requirements"
+(defined in point 16.3.1 of https://developers.google.com/youtube/devices/living-room/files/pdf-guides/YouTube_TV_HTML5_Technical_Requirements_2018.pdf).
+
+* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
+(WebCore::GStreamerRegistryScanner::isContentTypeSupported const):
+
+Canonical link: https://commits.webkit.org/290396@main
+---
+ .../graphics/gstreamer/GStreamerRegistryScanner.cpp      | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+index 3b48bb561437..8a396d2fc3f9 100644
+--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
++++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+@@ -778,6 +778,15 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
+         if (!isCodecSupported(configuration, codec, requiresHardwareSupport))
+             return SupportsType::IsNotSupported;
+     }
++
++    // The 'eotf' additional mime-type parameter must be supported to be compliant with
++    // "YouTube TV HTML5 Technical Requirements"
++    // (point 16.3.1 from https://developers.google.com/youtube/devices/living-room/files/pdf-guides/YouTube_TV_HTML5_Technical_Requirements_2018.pdf).
++    const auto eotf = contentType.parameter("eotf"_s);
++    if (!eotf.isEmpty()) {
++        if (eotf != "bt709"_s && eotf != "smpte2084"_s && eotf != "arib-std-b67"_s)
++            return SupportsType::IsNotSupported;
++    }
+     return SupportsType::IsSupported;
+ }
+ 
+-- 
+2.48.1
+

--- a/recipes-extended/wpe-webkit/files/2.38.8/comcast-RDKEMW-8425-HDR-DV-MediaCapabilities.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/comcast-RDKEMW-8425-HDR-DV-MediaCapabilities.patch
@@ -1,0 +1,256 @@
+From 84319f63aa7b41a11eaa590e415bc0939ec4db9c Mon Sep 17 00:00:00 2001
+From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+Date: Mon, 8 Sep 2025 14:41:09 +0200
+Subject: [PATCH 1/3] Support Dolby Vision codecs
+
+Some applications (like AppleTV+) explicitly checks MSE for DV codecs support
+and select proper stream based on that. Browser needs to report that
+Dolby vision codecs are supported.
+
+List 'dvhe' and 'dvh1' codecs in GStreamer registry scanner
+but make sure they are exposed only if platform screen supports HDR.
+
+WPEPlatform provides screen properties throuhg ScreenManager.
+When disabled, use fake screen properties with HDR support based on page settings.
+
+For WPE port only.
+---
+ Source/WebCore/platform/PlatformScreen.cpp    |  5 +++--
+ .../gstreamer/GStreamerRegistryScanner.cpp    | 20 +++++++++++++++++++
+ Source/WebKit/WebProcess/WebPage/WebPage.cpp  | 19 ++++++++++++++++++
+ 3 files changed, 42 insertions(+), 2 deletions(-)
+
+diff --git a/Source/WebCore/platform/PlatformScreen.cpp b/Source/WebCore/platform/PlatformScreen.cpp
+index ba50b688ab6d..258804c9a25e 100644
+--- a/Source/WebCore/platform/PlatformScreen.cpp
++++ b/Source/WebCore/platform/PlatformScreen.cpp
+@@ -26,9 +26,10 @@
+ #include "config.h"
+ #include "PlatformScreen.h"
+ 
+-#if PLATFORM(COCOA)
++#if PLATFORM(COCOA) || PLATFORM(WPE)
+ 
+ #include "ScreenProperties.h"
++#include <wtf/NeverDestroyed.h>
+ 
+ namespace WebCore {
+ 
+@@ -71,4 +72,4 @@ const ScreenData* screenData(PlatformDisplayID screenDisplayID)
+ 
+ } // namespace WebCore
+ 
+-#endif // PLATFORM(COCOA)
++#endif // PLATFORM(COCOA) || PLATFORM(WPE)
+diff --git a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+index 92bd67dc10ca..6c9767ee3818 100644
+--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
++++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+@@ -41,6 +41,11 @@
+ #include "VideoEncoderPrivateGStreamer.h"
+ #endif
+ 
++#if PLATFORM(WPE)
++#include "PlatformScreen.h"
++#include "ScreenProperties.h"
++#endif // PLATFORM(WPE)
++
+ namespace WebCore {
+ 
+ GST_DEBUG_CATEGORY_STATIC(webkit_media_gst_registry_scanner_debug);
+@@ -433,6 +438,10 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
+         m_decoderCodecMap.add(AtomString("x-h265"_s), h265DecoderAvailable);
+         m_decoderCodecMap.add(AtomString("hvc1*"_s), h265DecoderAvailable);
+         m_decoderCodecMap.add(AtomString("hev1*"_s), h265DecoderAvailable);
++#if PLATFORM(WPE)
++        m_decoderCodecMap.add(AtomString("dvhe*"_s), h265DecoderAvailable);
++        m_decoderCodecMap.add(AtomString("dvh1*"_s), h265DecoderAvailable);
++#endif // PLATFORM(WPE)
+     }
+ 
+     if (shouldAddMP4Container) {
+@@ -670,11 +679,22 @@ GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isCodecSup
+     size_t slashIndex = codec.find('/');
+     String codecName = slashIndex != notFound ? codec.substring(slashIndex + 1) : codec;
+ 
++#if PLATFORM(WPE)
++    bool supportsDVHCodec = false;
++    auto* scrData = screenData(primaryScreenDisplayID());
++    if (scrData && scrData->screenSupportsHighDynamicRange)
++        supportsDVHCodec = true;
++#endif // PLATFORM(WPE)
++
+     CodecLookupResult result;
+     if (codecName.startsWith("avc1"_s))
+         result = isAVC1CodecSupported(configuration, codecName, shouldCheckForHardwareUse);
+     else if (codecName.startsWith("hev1"_s) || codecName.startsWith("hvc1"_s))
+         result = isHEVCCodecSupported(configuration, codecName, shouldCheckForHardwareUse);
++#if PLATFORM(WPE)
++    else if ((codecName.startsWith("dvhe"_s) || codecName.startsWith("dvh1"_s)) && !supportsDVHCodec)
++        result = { false, nullptr };
++#endif // PLATFORM(WPE)
+     else {
+         auto& codecMap = configuration == Configuration::Decoding ? m_decoderCodecMap : m_encoderCodecMap;
+         for (const auto& [codecId, lookupResult] : codecMap) {
+diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+index f6937139abb6..7513daefe4a6 100644
+--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
++++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+@@ -424,6 +424,11 @@ static void SetMediaVolume(void *data, float volume) {
+ #endif
+ #endif
+ 
++#if PLATFORM(WPE) && !ENABLE(WPE_PLATFORM)
++#include <WebCore/PlatformScreen.h>
++#include <WebCore/ScreenProperties.h>
++#endif // PLATFORM(WPE) && !ENABLE(WPE_PLATFORM)
++
+ namespace WebKit {
+ using namespace JSC;
+ using namespace WebCore;
+@@ -4316,6 +4321,20 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
+ #endif
+ 
+     m_page->settingsDidChange();
++
++#if PLATFORM(WPE) && !ENABLE(WPE_PLATFORM)
++    // On WPE, we don't have a way to get screen properties from the system, so
++    // we fake them here based on the settings.
++    auto* currentScreenData = WebCore::screenData(primaryScreenDisplayID());
++    if (!currentScreenData || currentScreenData->screenSupportsHighDynamicRange != settings.screenSupportsHDR()) {
++        WebCore::ScreenData data;
++        data.screenSupportsHighDynamicRange = settings.screenSupportsHDR();
++        WebCore::ScreenProperties props;
++        props.primaryDisplayID = 1; // Fake display ID
++        props.screenDataMap.add(props.primaryDisplayID, WTFMove(data));
++        WebCore::setScreenProperties(props);
++    }
++#endif // PLATFORM(WPE) && !ENABLE(WPE_PLATFORM
+ }
+ 
+ #if ENABLE(DATA_DETECTION)
+-- 
+2.48.1
+
+
+From d594a198993634beca192b75078de569301f9429 Mon Sep 17 00:00:00 2001
+From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+Date: Tue, 9 Sep 2025 16:37:48 +0200
+Subject: [PATCH 2/3] Filter HDR content in MediaCapabilities querry
+
+Improve MediaCapabilites decoding support:
+1) Filter HDR related fields if screen doesn't support HDR.
+2) Both video and audio needs to be supported
+3) Include codecs check into the supported result
+---
+ .../gstreamer/GStreamerRegistryScanner.cpp    | 32 ++++++++++++++++---
+ 1 file changed, 27 insertions(+), 5 deletions(-)
+
+diff --git a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+index 6c9767ee3818..90fa9b101de0 100644
+--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
++++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+@@ -916,7 +916,6 @@ const char* GStreamerRegistryScanner::configurationNameForLogging(Configuration
+ 
+ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfigurationSupported(Configuration configuration, const MediaConfiguration& mediaConfiguration) const
+ {
+-    bool isSupported = false;
+     bool isUsingHardware = false;
+     const char* configLogString = configurationNameForLogging(configuration);
+ 
+@@ -927,11 +926,33 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
+             videoConfiguration.width, videoConfiguration.height,
+             videoConfiguration.bitrate, videoConfiguration.framerate);
+ 
++#if PLATFORM(WPE)
++        auto* scrData = screenData(primaryScreenDisplayID());
++        if (!scrData || !scrData->screenSupportsHighDynamicRange) {
++            // Check HDR metadata field
++            if (videoConfiguration.hdrMetadataType.has_value()) {
++                return { false, false, nullptr };
++            }
++            // Transfer function (EOTF)
++            if (videoConfiguration.transferFunction.has_value()) {
++                auto tf = videoConfiguration.transferFunction.value();
++                // compare to your enum values for PQ/HLG; adjust names if different
++                if (tf == TransferFunction::PQ || tf == TransferFunction::HLG) {
++                    return { false, false, nullptr };
++                }
++            }
++        }
++#endif // PLATFORM(WPE)
+         auto contentType = ContentType(videoConfiguration.contentType);
+-        isSupported = isContainerTypeSupported(configuration, contentType.containerType());
++        if (!isContainerTypeSupported(configuration, contentType.containerType()))
++            return { false, false, nullptr };
++
+         auto codecs = contentType.codecs();
+-        if (!codecs.isEmpty())
++        if (!codecs.isEmpty()) {
++            if (!areAllCodecsSupported(configuration, codecs, false))
++                return { false, false, nullptr };
+             isUsingHardware = areAllCodecsSupported(configuration, codecs, true);
++        }
+     }
+ 
+     if (mediaConfiguration.audio) {
+@@ -940,10 +961,11 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
+             audioConfiguration.contentType.utf8().data(), audioConfiguration.channels.utf8().data(),
+             audioConfiguration.bitrate.value_or(0), audioConfiguration.samplerate.value_or(0));
+         auto contentType = ContentType(audioConfiguration.contentType);
+-        isSupported = isContainerTypeSupported(configuration, contentType.containerType());
++        if (!isContainerTypeSupported(configuration, contentType.containerType()))
++            return { false, false, nullptr };
+     }
+ 
+-    return { isSupported, isUsingHardware, nullptr };
++    return { true, isUsingHardware, nullptr };
+ }
+ 
+ #if USE(GSTREAMER_WEBRTC)
+-- 
+2.48.1
+
+
+From f9448af1957d19b0231cf2619020301d6e724cac Mon Sep 17 00:00:00 2001
+From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+Date: Mon, 22 Sep 2025 09:46:49 +0200
+Subject: [PATCH 3/3] Set default value of ScreenSupportsHDR WebKit setting
+
+Base it on ENABLE_HDR build option
+---
+ Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp | 2 +-
+ Source/cmake/OptionsWPE.cmake                       | 7 +++++++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+index a9d484bcdb49..25f31b5fabf7 100644
+--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
++++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+@@ -1824,7 +1824,7 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
+         "screen-supports-hdr",
+         _("Screen supports HDR"),
+         _("Does screen support HDR."),
+-        FALSE,
++        ENABLE_HDR,
+         readWriteConstructParamFlags);
+ 
+     g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
+index 77d3a0a57b09..9cbc55b11dd1 100644
+--- a/Source/cmake/OptionsWPE.cmake
++++ b/Source/cmake/OptionsWPE.cmake
+@@ -452,3 +452,10 @@ endif()
+ if (USE_WPEWEBKIT_PLATFORM_BROADCOM)
+   add_definitions(-DBROADCOM_PLATFORM=1)
+ endif()
++
++if (ENABLE_HDR)
++  add_definitions(-DENABLE_HDR=1)
++else()
++  add_definitions(-DENABLE_HDR=0)
++endif()
++
+-- 
+2.48.1
+

--- a/recipes-extended/wpe-webkit/wpe-webkit.inc
+++ b/recipes-extended/wpe-webkit/wpe-webkit.inc
@@ -97,6 +97,7 @@ RDEPS_VIDEO = " \
     gstreamer1.0-plugins-base-playback \
     gstreamer1.0-plugins-good-soup \
     gstreamer1.0-plugins-bad-opusparse \
+    gstreamer1.0-plugins-good-matroska \
 "
 
 RDEPS_WEBAUDIO = " \

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.38.8.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.38.8.bb
@@ -3,7 +3,7 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r9"
+PR  = "r10"
 
 # Temporary build fix
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
@@ -20,6 +20,8 @@ SRC_URI = "${BASE_URI}"
 SRC_URI += "file://2.38.2/1196.patch"
 SRC_URI += "file://2.38.6/1384.patch"
 SRC_URI += "file://2.38.7/1410.patch"
+SRC_URI += "file://2.38.8/1448_Added-API-to-get-and-set-screen-supports-HDR-setting.patch"
+SRC_URI += "file://2.38.8/1463_GStreamer-support-the-eotf-additional-MIME-type.patch"
 
 # Drop after issue is addressed and a corresponding PR is merged
 SRC_URI += "file://2.38.8/1456-RDKTV-35082-Workaround-premature-finishSeek.patch"
@@ -49,7 +51,6 @@ SRC_URI += "file://2.38/comcast-LLAMA-2184-Support-for-external-sink-for-x-d.pat
 SRC_URI += "file://2.38/comcast-XRE-13799-XRE-13989-Track-encrypted-playback.patch"
 SRC_URI += "file://2.38.4/comcast-RDK-28954-SERXIONE-4574-Minidump-exception-h.patch"
 SRC_URI += "file://2.38/comcast-RDKTV-17737-play-pause-mapping.patch"
-SRC_URI += "file://2.38.5/comcast-XRE-15382-XIONE-4595-RDKTV-17736-HDR-DV-conf.patch"
 SRC_URI += "file://2.38/comcast-RDKTV-17281-RDKTV-17781-Workaround-for-AppleTV-rende.patch"
 SRC_URI += "file://2.38/comcast-RDKTV-18852-Restrict-inspection-of-locally-h.patch"
 SRC_URI += "file://2.38/comcast-LLAMA-8030-Fix-init-data-filtering.patch"
@@ -76,6 +77,7 @@ SRC_URI += "file://2.38.8/comcast-LLAMA-16805-Include-HW-secure-decrypt-decode-i
 SRC_URI += "file://2.38.8/comcast-dynamic-insertion-of-decryptor.patch"
 SRC_URI += "file://2.38.8/comcast-RDKEMW-2744-BitmapTextureGL-Check-EGL-context.patch"
 SRC_URI += "file://2.38.8/comcast-DELIA-68848-webrtc-improvements.patch"
+SRC_URI += "file://2.38.8/comcast-RDKEMW-8425-HDR-DV-MediaCapabilities.patch"
 
 PACKAGECONFIG[wpeqtapi]          = "-DENABLE_WPE_QT_API=ON,-DENABLE_WPE_QT_API=OFF"
 PACKAGECONFIG[westeros]          = "-DUSE_WPEWEBKIT_PLATFORM_WESTEROS=ON -DUSE_GSTREAMER_HOLEPUNCH=ON -DUSE_EXTERNAL_HOLEPUNCH=ON -DUSE_WESTEROS_SINK=ON,,westeros virtual/vendor-westeros-sink"
@@ -83,11 +85,10 @@ PACKAGECONFIG[encryptedmedia]    = "-DENABLE_ENCRYPTED_MEDIA=ON,-DENABLE_ENCRYPT
 PACKAGECONFIG[mathml]            = "-DENABLE_MATHML=ON,-DENABLE_MATHML=OFF,"
 PACKAGECONFIG[touchevents]       = "-DENABLE_TOUCH_EVENTS=ON,-DENABLE_TOUCH_EVENTS=OFF,"
 PACKAGECONFIG[remoteinspector]   = "-DENABLE_REMOTE_INSPECTOR=ON,-DENABLE_REMOTE_INSPECTOR=OFF,"
-PACKAGECONFIG[vp9_hdr]           = "-DENABLE_HDR=ON,-DENABLE_HDR=OFF,,gstreamer1.0-plugins-good-matroska"
+PACKAGECONFIG[vp9_hdr]           = "-DENABLE_HDR=ON,-DENABLE_HDR=OFF,,"
 PACKAGECONFIG[gstreamergl]       = "-DUSE_GSTREAMER_GL=ON,-DUSE_GSTREAMER_GL=OFF,"
 PACKAGECONFIG[mediastream]       = "-DENABLE_MEDIA_STREAM=ON -DENABLE_WEB_RTC=ON,-DENABLE_MEDIA_STREAM=OFF -DENABLE_WEB_RTC=OFF,libevent libopus libvpx alsa-lib,libevent"
 PACKAGECONFIG[asan]              = "-DENABLE_SANITIZERS=address,,gcc-sanitizers"
-PACKAGECONFIG[dolbyvision]       = "-DENABLE_DV=ON,-DENABLE_DV=OFF,,"
 PACKAGECONFIG[developermode]     = "-DDEVELOPER_MODE=ON -DENABLE_COG=OFF,-DDEVELOPER_MODE=OFF,wpebackend-fdo wayland-native,"
 PACKAGECONFIG[accessibility]     = "-DENABLE_ACCESSIBILITY=ON,-DENABLE_ACCESSIBILITY=OFF,atk tts rdkat,rdkat"
 PACKAGECONFIG[speechsynthesis]   = "-DENABLE_SPEECH_SYNTHESIS=ON,-DENABLE_SPEECH_SYNTHESIS=OFF,tts"
@@ -113,13 +114,11 @@ PACKAGECONFIG[lcms]              = "-DUSE_LCMS=ON,-DUSE_LCMS=OFF, "
 PACKAGECONFIG[webassembly]       = "-DENABLE_WEBASSEMBLY=ON,-DENABLE_WEBASSEMBLY=OFF -DENABLE_WEBASSEMBLY_B3JIT=OFF, "
 PACKAGECONFIG[malloc_heap_breakdown] = "-DENABLE_MALLOC_HEAP_BREAKDOWN=ON,-DENABLE_MALLOC_HEAP_BREAKDOWN=OFF,malloc-zone, malloc-zone"
 PACKAGECONFIG[pdfjs]             = "-DENABLE_PDFJS=ON,-DENABLE_PDFJS=OFF,,"
-PACKAGECONFIG[dolbyvision]       = "-DENABLE_DV=ON,-DENABLE_DV=OFF,,"
-PACKAGECONFIG[vp9_hdr]           = "-DENABLE_HDR=ON,-DENABLE_HDR=OFF,,gstreamer1.0-plugins-good-matroska"
 PACKAGECONFIG[instantratechange] = "-DENABLE_INSTANT_RATE_CHANGE=ON,-DENABLE_INSTANT_RATE_CHANGE=OFF,"
 PACKAGECONFIG[logs]              = "-DENABLE_LOGS=ON,,"
 PACKAGECONFIG[fhd]               = "-DVIDEO_DECODING_LIMIT=1920x1080@60,,"
 
-PACKAGECONFIG:append = " vp9_hdr dolbyvision breakpad native_video woff2 serviceworker"
+PACKAGECONFIG:append = " vp9_hdr breakpad native_video woff2 serviceworker"
 PACKAGECONFIG:append = " webcrypto webdriver remoteinspector releaselog accessibility speechsynthesis webaudio instantratechange"
 PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'enable_libsoup3', 'usesoup3', 'usesoup2', d)}"
 PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'malloc_heap_breakdown', 'malloc_heap_breakdown', '', d)}"
@@ -129,7 +128,6 @@ PACKAGECONFIG:append = " ${@bb.utils.contains('BROWSER_MEMORYPROFILE', 'fhd', 'f
 PACKAGECONFIG:append:aarch64 = " webassembly"
 
 PACKAGECONFIG:remove = "${@bb.utils.contains('HAS_HDR_SUPPORT', '0', 'vp9_hdr', '', d)}"
-PACKAGECONFIG:remove = "${@bb.utils.contains('HAS_DOLBY_VISION_SUPPORT', '0', 'dolbyvision', '', d)}"
 
 EXTRA_OECMAKE += " \
   -DPYTHON_EXECUTABLE=${STAGING_BINDIR_NATIVE}/python3-native/python3 \


### PR DESCRIPTION
RDKEMW-8425: Runtime HDR & DV WebKit settings for 2.38.8

Reason for change: Rungime HDR & DV settings for webkit 2.38.8
Test Procedure: WebApps smoke testing
Priority: P1
Risks: Low