### PR TITLE
RDKE-900: Default to MTLS connection on all endpoints

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
           "
 
 # Release version - 3.1.19
-SRCREV = "c5d534a96765a42660e33ec9e154ce9dd9e2abb7"
+SRCREV = "953531a29084247b32b24f60f47da071e13d0e0d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Update entservices-deviceanddisplay.bb