### PR TITLE
RDKEMW-8491: Remove ctrlm-hal-irdb from MW

### DIFF
--- a/recipes-extended/ctrlm/ctrlm-headers.bb
+++ b/recipes-extended/ctrlm/ctrlm-headers.bb
@@ -54,11 +54,6 @@ do_install() {
     # Advanced Secure Binding
     install -m 644 ${S}/src/asb/ctrlm_asb.h ${D}${includedir}/ctrlm_private
 
-    # IRDB Support
-    install -m 644 ${S}/src/irdb/ctrlm_irdb_interface.h ${D}${includedir}/ctrlm_private
-    install -m 644 ${S}/src/ipc/ctrlm_ipc_iarm.h ${D}${includedir}/ctrlm_private
-    install -m 644 ${S}/src/irdb/ctrlm_irdb_plugin.h ${D}${includedir}/ctrlm_private
-
     # Network Support
     install -m 644 ${S}/src/ctrlm.h ${D}${includedir}/ctrlm_private
     install -m 644 ${S}/src/ctrlm_rcu.h ${D}${includedir}/ctrlm_private


### PR DESCRIPTION
IRDB plugin is built in the vendor layers now, so the middleware doesn't need the IRDB HAL headers installed.