### PR TITLE
RDKEMW-7523 - NetworkManager Plugin Release - 1.4.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "1.3.0"
+PV = "1.4.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Sep 17, 2025
-SRCREV = "9709dd5f5ed714bf6f6f41e0c368dcd804b16e71"
+# Sep 23, 2025
+SRCREV = "a753fdfcb462c2cbda4e6c7aeb5bf48f7333c36f"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 1.4.0 with following Bug fixes
- Implemented logic to not to persist SSID when asked
- Implemented IP Address caching to avoid making RPC request to networkmanager when interface status not changed.
- Fixed the Router Discovery app crash when AP does not support UPNP