### PR TITLE
RDKE-900: Default to MTLS connection on all endpoints

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
           "
 
 # Release version - 3.2.0
-SRCREV = "5d7ed5648ab54a3518e58cb03c5c4d5ddbc03747"
+SRCREV = "bc47fdd2bdbec9df8b738a562fb5dcd06ad6c6be"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Update entservices-deviceanddisplay.bb