### PR TITLE
RDKEMW-3037: Premerge CI : integrate MW dev support in IA with the su…

### DIFF
--- a/recipes-extended/wpe-framework/thunder-hang-recovery.bb
+++ b/recipes-extended/wpe-framework/thunder-hang-recovery.bb
@@ -3,7 +3,7 @@ SUMMARY = "Thunder Hang Recovery Application"
 DESCRIPTION = "Application to recovery thunder when it hangs by restarting thunder wpeframework"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://${COREBASE}/../../middleware/generic/meta-rdk-video/LICENSE;md5=5bfad6e034e497ee148eec56e175c6e8"
+LIC_FILES_CHKSUM = "file://${THISDIR}/../../LICENSE;md5=5bfad6e034e497ee148eec56e175c6e8"
 
 PR = "r0"
 PV = "1.0.0"


### PR DESCRIPTION
…bmaniest inclusion

Reason for change:
	 Premerge CI : integrate MW dev support in IA with the submaniest inclusion

Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>