### PR TITLE
RDKEMW-9052: JSON Parsing failing for string with \" over websocket

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/Revert_PR-665_support_JSON_Parsing.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/Revert_PR-665_support_JSON_Parsing.patch
@@ -1,0 +1,33 @@
+diff --git a/Source/core/JSON.h b/Source/core/JSON.h
+index e6293d876..5a10b955f 100644
+--- a/Source/core/JSON.h
++++ b/Source/core/JSON.h
+@@ -1937,7 +1937,7 @@ namespace Core {
+                             // We are assumed to be opaque, but all quoted string stuff is enclosed between quotes
+                             // and should be considered for scope counting.
+                             // Check if we are entering or leaving a quoted area in the opaque object
+-                            if ((current == '\"') && ((_value.empty() == true) || IsEscaped(_value))) {
++                            if ((current == '\"') && ((_value.empty() == true) || (_value[_value.length() - 2] != '\\'))) {
+                                 // This is not an "escaped" quote, so it should be considered a real quote. It means
+                                 // we are now entering or leaving a quoted area within the opaque struct...
+                                 _flagsAndCounters ^= QuotedAreaBit;
+@@ -2135,19 +2135,6 @@ namespace Core {
+             }
+ 
+         private:
+-            bool IsEscaped(const string& value) const {
+-                // This code determines if a lot of back slashes to esscape the backslash
+-                // Is odd or even, so does it escape the last character..
+-                // e.g. 'Test \\\\\\\\\\"' is not the escaping of the quote (")
+-                //      'Test \\\\\\\\\" continued"'  is the escaping of th quote..
+-                //      'Test \" and \" and than \\\"' are all escaped quotes 
+-                uint32_t index = static_cast<uint32_t>(value.length() - 1);
+-                uint32_t start = index;
+-                while ( (index != static_cast<uint32_t>(~0)) && (value[index] == '\\') ) {
+-                    index--;
+-                }
+-                return (((start - index) % 2) == 0);
+-            }
+             bool InScope(const ScopeBracket mode) {
+                 bool added = false;
+                 uint8_t depth = (_flagsAndCounters & 0x1F);

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -47,6 +47,7 @@ SRC_URI += "file://wpeframework-init \
            file://r4.4/Activating_plugins_Logs_COMRPC.patch \
            file://r4.4/Removed_Autostart_Check_From_WPEFramework.patch \
            file://r4.4/Append_WorkerPool_Info.patch \
+           file://r4.4/Revert_PR-665_support_JSON_Parsing.patch \
            "
 
 SRC_URI += "file://r4.4/PR-1369-Wait-for-Open-in-Communication-Channel.patch \


### PR DESCRIPTION
Reason for Change:Validated the Thunder R4.4.3 + RDK patch using the BigJSONTest Test Plugin. The TestConsumer receives only the first three events. The fourth event is not notified to the consumer—it gets stuck at the Thunder layer. The fifth event is received by the Thunder layer but gets mixed up with the pending fourth message, causing deserialization errors due to the combined data from both messages. After this point, no further events are received or notified, and the Thunder layer enters a bad state. I suspected the Metro changes introduced in PR #1625. After reverting those changes and revalidating, the issue was resolved Test Procedure:Please refer to the ticket description. Risks: Medium
Priority: P1