### PR TITLE
RDKEMW-9572,RDKECOREMW-1011: Fix for Miracast Service crash while reactivating the service

### DIFF
--- a/recipes-extended/entservices/entservices-casting.bb
+++ b/recipes-extended/entservices/entservices-casting.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-casting;${CMF_GITHUB_SRC_URI_SUFFIX} \
           "
 
 # Release version - 1.2.7
-SRCREV = "68a3bf90cd422d7b3c2523d712981b69e9b59b4a"
+SRCREV = "3832ff80734da192e0db5a8d4382ad28ac597a97"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
To build below PR for entservices-casting for miracast crash while reactivating the service.
https://github.com/rdkcentral/entservices-casting/pull/135

