### PR TITLE
RDKEMW-9423 : Log the milestone marker for WPE_FRAMEWORK_START

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -17,6 +17,7 @@ Environment="XDG_DATA_HOME=/opt/QT/home"
 Environment="FORCE_SVP=TRUE"
 Environment="FORCE_SAP=TRUE"
 SyslogIdentifier=WPEFramework
+ExecStartPre=-/usr/bin/rdkLogMileStone WPE_FRAMEWORK_START
 ExecStart=/bin/bash -c 'if [ -f /opt/WPEFramework/config.json ]; then exec /usr/bin/WPEFramework -b -c /opt/WPEFramework/config.json; else exec /usr/bin/WPEFramework -b; fi'
 # Manually adding PID file support. This is used by Thunder clients to know if
 # Thunder aka WPEFramework process is restarted. Please note if PIDFile name is changed


### PR DESCRIPTION
Reason for change: Logging the milestone for WPE_FRAMEWORK_START
Test Procedure: Boot the TV and check the /opt/logs/rdk_milestones.log
Risks: low