### PR TITLE
RDKEMW-7465 : NetworkManager Plugin Release - 1.5.0

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "1.4.0"
+PV = "1.5.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Sep 23, 2025
-SRCREV = "a753fdfcb462c2cbda4e6c7aeb5bf48f7333c36f"
+# Oct 25, 2025
+SRCREV = "dead85eb29bb8ca79b5f725f51294959a8a1f9c8"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry  ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', ' iarmbus iarmmgrs ', d)} "


### PR DESCRIPTION
RDKEMW-7465 : NetworkManager Plugin Release - 1.5.0

- Implemented L1/L2 and Part L3 for the plugin
- Implemented IP Address caching for Gnome backend
- Implemented a logic to return appropriate value for GetPrimaryInterface