### PR TITLE
RDKEMW-8289 : CEC is not working after an FSR

### DIFF
--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.4.11
-SRCREV = "2c8ea51982ad74d617ad5018e151b399f5e0b8cc"
+# Release version - 1.5.1
+SRCREV = "91344a0f05f40a58c3de09ef49ba4d238d8b0886"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
RDKEMW-8289 : CEC is not working after an FSR

Reason for change: Added new function such that on de-init we will not persist the disabled CEC status Test Procedure:
Risks: low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>