### PR TITLE
RDKEMW-9328 : RDK-E : ES1 RTK STB - VL 1.0.0 mw int

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -10,6 +10,7 @@ inherit cmake pkgconfig
 
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
+           file://es1_rtk_gCrrRes.patch \
           "
 
 # Release version - 3.2.9

--- a/recipes-extended/entservices/files/es1_rtk_gCrrRes.patch
+++ b/recipes-extended/entservices/files/es1_rtk_gCrrRes.patch
@@ -1,0 +1,20 @@
+diff --git a/DisplaySettings/DisplaySettings.cpp b/DisplaySettings/DisplaySettings.cpp
+index 6d56aec..bb7031e 100755
+--- a/DisplaySettings/DisplaySettings.cpp
++++ b/DisplaySettings/DisplaySettings.cpp
+@@ -1155,8 +1155,13 @@ namespace WPEFramework {
+             }
+             catch(const device::Exception& err)
+             {
+-                LOG_DEVICE_EXCEPTION1(videoDisplay);
+-                success = false;
++                response["resolution"] = std::string("720p");
++                response["w"] = 1280;
++                response["h"] = 720;
++                response["progressive"] = true;
++                success = true;
++                //LOG_DEVICE_EXCEPTION1(videoDisplay);
++                //success = false;
+             }
+             returnResponse(success);
+         }


### PR DESCRIPTION
Reason for change:
	 RDK-E : ES1 RTK STB - VL 1.0.0 mw int get current resolution
	 DONOT MERGE : TEMP PATCH

Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>