### PR TITLE
VPLAY - 11597 Add CP error range to allowed list

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/Jsonrpc_dynamic_error_handling.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/Jsonrpc_dynamic_error_handling.patch
@@ -17,6 +17,8 @@ index 8d52c7485..19e037580 100644
 +
 +                            if( frameworkError <= 999 ) {
 +                                Code = static_cast<int32_t>(frameworkError);
++                            } else if ( frameworkError >= 21000 && frameworkError < 24000 )  {
++                                Code = static_cast<int32_t>(frameworkError);
 +                            } else {
 +                                Code = -31000 - static_cast<int32_t>(frameworkError);
 +                            }


### PR DESCRIPTION
Reason for change: Add 21000 - 23999 range to allowed error code list
Test Procedure: Test CP plugin error responses
Risks: Low
Priority: P1