### PR TITLE
RDKEMW-9015: Bump TextTrack to opensource

### DIFF
--- a/recipes-extended/texttrack/files/config.ini
+++ b/recipes-extended/texttrack/files/config.ini
@@ -1,0 +1,97 @@
+#
+# SubTtxRend-App configuration file, used by TextTrack.
+#
+
+#
+# Application configuration
+#
+
+# - Teletext G0 charset font
+#   (glyph width / height should be normally equal to 40x25 grid cell size)
+#   (char width/height is specified as freetype points and used for scaling)
+#
+RDKENV.FEATURE.TTX.FONT.G0.NAME = Teletext 43
+# RDKENV.FEATURE.TTX.FONT.G0.GLYPH_WIDTH = 22
+# RDKENV.FEATURE.TTX.FONT.G0.GLYPH_HEIGHT = 26
+# RDKENV.FEATURE.TTX.FONT.G0.CHAR_WIDTH = 34
+# RDKENV.FEATURE.TTX.FONT.G0.CHAR_HEIGHT = 24
+#
+# - Teletext flash period in milliseconds
+#
+# RDKENV.FEATURE.TTX.FLASH_PERIOD_MS = 1000
+#
+# - Teletext default background alpha
+#
+# RDKENV.FEATURE.TTX.BG_ALPHA = 255
+#
+# - Should ttx engine be reset or destroyed when decoding stops
+#
+# RDKENV.FEATURE.TTX.RESET_ON_STOP = TRUE
+
+#
+#-----------------------------------
+# Teletext settings
+#-----------------------------------
+#
+# TELETEXT.WINDOW.W = 1280
+# TELETEXT.WINDOW.H = 720
+#
+# (grid size is 40x25, zoomed 40x13)
+# TELETEXT.GRID_CELL.W = 22
+# TELETEXT.GRID_CELL.H = 26
+#
+TELETEXT.FONT_G0_G2.NAME = Teletext 43
+# TELETEXT.FONT_G0_G2.W = 34
+# TELETEXT.FONT_G0_G2.H = 24
+#
+# TELETEXT.FLASH_PERIOD_MS = 1000
+#
+# TELETEXT.BG_ALPHA = 255
+#
+#-----------------------------------
+# Ttml settings
+#-----------------------------------
+# - debug feature- enabling below option will dump all incoming ttml data (document and images) to given directory
+# - !!! remember to remove the files
+# TTML.DUMP_DIR = /var/run/subttx/ttml_dump/
+#
+# - debug feature- dump incoming data to log/journal
+# TTML.DUMP_TO_LOG = 1
+#
+# - debug feature - show current mediatime on screen
+# TTML.SHOW_MEDIATIME = 1
+#
+# - debug feature - read ttml from file
+# TTML.READ_FROM_FILE = /var/run/subttx/ttml_src/data.ttml
+#
+# - if defined ttml renderer will always use this font name regardless of ttml::fontFamily
+TTML.FORCE_FONT = Cinecav Sans
+WEBVTT.FONT.FAMILY = Cinecav Sans
+#
+# - debug feature - color ttml regions; 0x99c2f0c2 is semi-transparent lightly green
+# TTML.REGIONS_FILL_COLOR = 0x99c2f0c2
+
+#-----------------------------------
+# Logger settings
+#-----------------------------------
+#
+# - Backend selection and configuration
+# -- std (standard output) is default backend
+# LOGGER.BACKEND = std | rdk
+# LOGGER.BACKEND_RDK_CONFIG_FILE = /etc/debug.ini
+#
+# - Message levels enabled configuration
+#
+# LOGGER.LEVELS_DEFAULT = FATAL ERROR WARNING INFO
+# LOGGER.LEVELS.<component> = levels
+# LOGGER.LEVELS.<component>.<element> = levels
+# levels = ALL FATAL ERROR WARNING INFO DEBUG TRACE
+#
+# To enable level and all more important levels use level name with '+'
+# character at the end e.g. "INFO+" (means INFO WARNING ERROR FATAL).
+#
+LOGGER.LEVELS_DEFAULT = WARNING+
+# CORE.INFO has some possibly useful logging to check that services are running
+LOGGER.LEVELS.CORE = INFO+
+# Actual subtitles are logged as INFO. We don't want those by default.
+# LOGGER.LEVELS.REND = INFO+

--- a/recipes-extended/texttrack/files/texttrack.conf
+++ b/recipes-extended/texttrack/files/texttrack.conf
@@ -1,0 +1,4 @@
+# Ensure existence of necessary temporary directory
+
+# type path mode user group
+d /var/run/subttx 0750 root users

--- a/recipes-extended/texttrack/texttrack.bb
+++ b/recipes-extended/texttrack/texttrack.bb
@@ -1,0 +1,62 @@
+SUMMARY = "Text Track Plugin"
+DESCRIPTION = "Text Track Plugin Meta Package"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+SRCREV = "635553bbfa1234f231c15165d3018ce79972b1a8"
+PV = "1.4.0"
+PR = "r0"
+PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
+
+inherit cmake features_check pkgconfig
+
+# This recipe supports one distro-feature:
+# texttrack : enables full functionality, including session management and compatibility socket
+REQUIRED_DISTRO_FEATURES = "texttrack"
+
+SRC_URI = "${CMF_GITHUB_ROOT}/texttrack;protocol=${CMF_GIT_PROTOCOL};branch=main"
+SRC_URI += "file://texttrack.conf"
+SRC_URI += "file://config.ini"
+S = "${WORKDIR}/git"
+
+# Build depends
+DEPENDS += " entservices-apis wpeframework-tools-native"
+DEPENDS += " subttxrend-ctrl subttxrend-common subttxrend-socksrc"
+DEPENDS += " subttxrend-gfx subttxrend-protocol"
+
+# Image depends
+#RDEPENDS:${PN} = ""
+
+# Autostart variants
+# Handled automatically by "thunderstartupservices"
+
+# Make it possible to override this in .bbappend files
+TEXTTRACK_STANDARD_DISPLAY ?= "westeros-asplayer-subtitles"
+
+PACKAGECONFIG:append = " sessions cchal"
+# Even though RDK-E does run with Dobby containers, it does not have the dobbyapp user, so this config is irrelevant
+# PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'DOBBY_CONTAINERS', 'dobbyapp', '', d)}"
+
+PACKAGECONFIG[debug] = "-DCMAKE_BUILD_TYPE=Debug,-DCMAKE_BUILD_TYPE=Release,"
+PACKAGECONFIG[sessions] = "-DTEXTTRACK_WITH_SESSIONS=ON,-DTEXTTRACK_WITH_SESSIONS=OFF,,,,"
+PACKAGECONFIG[dobbyapp] = "-DTEXTTRACK_WITH_CHOWN_DOBBYAPP=ON,-DTEXTTRACK_WITH_CHOWN_DOBBYAPP=OFF,,,,"
+PACKAGECONFIG[cchal] = "-DTEXTTRACK_WITH_CCHAL=ON,-DTEXTTRACK_WITH_CCHAL=OFF,closedcaption-hal-headers virtual/vendor-closedcaption-hal,,,"
+
+EXTRA_OECMAKE += " -DTEXTTRACK_STANDARD_DISPLAY=${TEXTTRACK_STANDARD_DISPLAY}"
+EXTRA_OECMAKE += " -DTEXTTRACK_AUTOSTART=true"
+EXTRA_OECMAKE += " -DTEXTTRACK_CONFIG_FILE_PATH=${sysconfdir}/texttrack/config.ini"
+
+do_install:append() {
+    install -D -m 0644 -t ${D}${sysconfdir}/tmpfiles.d ${WORKDIR}/texttrack.conf
+    install -D -m 0644 -t ${D}${sysconfdir}/texttrack ${WORKDIR}/config.ini
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'thunder_startup_services', 'true', 'false', d)} == 'true'; then
+        if [ -d "${D}/etc/WPEFramework/plugins" ]; then
+            find ${D}/etc/WPEFramework/plugins/ -type f | xargs sed -i -r 's/"autostart"[[:space:]]*:[[:space:]]*true/"autostart":false/g'
+        fi
+    fi
+}
+
+#
+# files to be installed
+#
+FILES:${PN} += "${libdir}/wpeframework/* ${datadir}/WPEFramework/*"

--- a/recipes-extended/thunderstartupservices/files/wpeframework-texttrack.service
+++ b/recipes-extended/thunderstartupservices/files/wpeframework-texttrack.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=WPEFramework TextTrack Initialiser
+Requires=wpeframework.service sky-appsservice.service
+After=wpeframework.service wpeframework-persistentstore.service sky-appsservice.service
+ConditionPathExists=/tmp/wpeframeworkstarted
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/usr/bin/appsservicectl start-subtitles-client
+ExecStart=/usr/bin/PluginActivator org.rdk.TextTrack
+

--- a/recipes-extended/thunderstartupservices/thunderstartupservices.bb
+++ b/recipes-extended/thunderstartupservices/thunderstartupservices.bb
@@ -8,8 +8,9 @@ PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 DEPENDS = "systemd"
 
-SRC_URI = "git://github.com/rdkcentral/thunder-startup-services.git;protocol=git;name=thunderstartupservices \
+SRC_URI = "${CMF_GITHUB_ROOT}/thunder-startup-services.git;protocol=${CMF_GITHUB_PROTOCOL};name=thunderstartupservices;branch=main \
     ${@bb.utils.contains('DISTRO_FEATURES', 'RDKE_PLATFORM_TV', 'file://0002-displaysettings-tv-deps.patch', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'texttrack', 'file://wpeframework-texttrack.service;subdir=git/systemd/system', '', d)} \
 "
 S = "${WORKDIR}/git/systemd/system"
 
@@ -58,6 +59,7 @@ THUNDER_STARTUP_SERVICES:append = "\
     wpeframework-fbsettings.service \
     wpeframework-downloadmanager.service \
     wpeframework-preinstallmanager.service \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'texttrack', 'wpeframework-texttrack.service', '', d)} \
     "
 
 CONTROL_FILES = "\


### PR DESCRIPTION
RDKEMW-9015: Bump TextTrack to opensource
Moved the recipe here from CSPC section. Moved the installation of its service file with thunderstartupservices here as well - this can/should later be committed into the repository.