### PR TITLE
RDKEMW-9222 -  Add CP error range to allowed list (VPLAY-11597)

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/Jsonrpc_dynamic_error_handling.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/Jsonrpc_dynamic_error_handling.patch
@@ -1,8 +1,8 @@
 diff --git a/Source/core/JSONRPC.h b/Source/core/JSONRPC.h
-index 8d52c7485..19e037580 100644
+index 8d52c748..6028cdb8 100644
 --- a/Source/core/JSONRPC.h
 +++ b/Source/core/JSONRPC.h
-@@ -138,7 +138,23 @@ namespace Core {
+@@ -138,7 +138,24 @@ namespace Core {
                          break;
                      default:
                          Code = static_cast<int32_t>(frameworkError);
@@ -14,8 +14,9 @@ index 8d52c7485..19e037580 100644
 +                            // one hand keep the current Thunder error codes used in 4.4 backwards compatible (so the numbers as reported in
 +                            // json rpc will not change) while at the same time making sure that code used in dynamic json rpc override will behave
 +                            // as in Thunder 5 (so if the error code is changed to 1000 there it will result in a -32000 error code reported for json rpc)
++                            // New range > 2000 is added for pass through for a temporary fix for ContentProtection range
 +
-+                            if( frameworkError <= 999 ) {
++                            if( frameworkError <= 999  || frameworkError > 2000 ) {
 +                                Code = static_cast<int32_t>(frameworkError);
 +                            } else {
 +                                Code = -31000 - static_cast<int32_t>(frameworkError);
@@ -28,7 +29,7 @@ index 8d52c7485..19e037580 100644
                      }
                  }
 diff --git a/Source/plugins/JSONRPC.h b/Source/plugins/JSONRPC.h
-index 8f23df367..1ae2e22d4 100644
+index 8f23df36..1ae2e22d 100644
 --- a/Source/plugins/JSONRPC.h
 +++ b/Source/plugins/JSONRPC.h
 @@ -28,6 +28,23 @@


### PR DESCRIPTION
Reason for change: Add 21000 - 23999 range to allowed error code list
Test Procedure: Test CP plugin error responses
Risks: Low
Priority: P1