### PR TITLE
RDKEMW-10538 : Do not Print Personal information about WIFI

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "0.20.4"
+PV = "0.20.5"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=support/0.20.0"
 
-# Nov 9, 2025
-SRCREV = "9f7b0a904a3975eb8f727b3a4246befbee0720fb"
+# Nov 14, 2025
+SRCREV = "e916fc433a7f9edd927427e571723759c3464d59"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry iarmbus iarmmgrs ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', '', d)} "


### PR DESCRIPTION
Reason for change: Removed printing of wifi password from mfr migration changes
Test Procedure: Check the log for wifi credentials
Priority:P0
Risks: Medium