### PR TITLE
RDKEMW-10577: Run Thunder in foreground

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -18,7 +18,7 @@ Environment="FORCE_SVP=TRUE"
 Environment="FORCE_SAP=TRUE"
 ExecStartPre=-/usr/bin/rdkLogMileStone WPE_FRAMEWORK_START
 SyslogIdentifier=WPEFramework
-ExecStart=/usr/bin/WPEFramework -b
+ExecStart=/usr/bin/WPEFramework -f
 # Manually adding PID file support. This is used by Thunder clients to know if
 # Thunder aka WPEFramework process is restarted. Please note if PIDFile name is changed
 # it will need corresponding code change in ThunderClientLibraries (power_controller) too.


### PR DESCRIPTION
RDKEMW-10577 : Run Thunder in foreground

Reason for change: now Thunder running in background and modified the changes to foreground
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1