### PR TITLE
RDKECOREMW-1166:Update entservices-inputoutput.bb

### DIFF
--- a/recipes-extended/entservices/entservices-inputoutput.bb
+++ b/recipes-extended/entservices/entservices-inputoutput.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-inputoutput;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.5.1
-SRCREV = "d561971cfe026bb61f63fe60cce61291e4e9124f"
+SRCREV = "8eb97e7c6835a18f0c370e6cd8db35be21cdc805"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change : Exception Handling in HdmiCecSource
Test Procedure    : Build is successful 
Priority          : Unprioritized
Risks             : None