### PR TITLE
RDK-59913 : Enabling Cobalt 25 as default distro in RDK E

### DIFF
--- a/recipes-extended/cobalt/cobalt-evergreen-pbt_25.lts.stable.bb
+++ b/recipes-extended/cobalt/cobalt-evergreen-pbt_25.lts.stable.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://../COBALT_LICENSE;md5=0fca02217a5d49a14dfe2d11837bb34d"
 
 inherit features_check
-REQUIRED_DISTRO_FEATURES = "cobalt-25"
+CONFLICT_DISTRO_FEATURES = "cobalt-24"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/evergreen:"
 DEPENDS += "unzip-native breakpad-native"

--- a/recipes-extended/cobalt/cobalt-evergreen-src_25.lts.stable.bb
+++ b/recipes-extended/cobalt/cobalt-evergreen-src_25.lts.stable.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 inherit features_check
-REQUIRED_DISTRO_FEATURES = "cobalt-25"
+CONFLICT_DISTRO_FEATURES = "cobalt-24"
 
 TOOLCHAINS_DIR = "starboard-toolchains"
 CLANG_BUILD_REVISION = "17-init-8029-g27f27d15-3"

--- a/recipes-extended/cobalt/libloader-app_25.lts.stable.bb
+++ b/recipes-extended/cobalt/libloader-app_25.lts.stable.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 inherit features_check
-REQUIRED_DISTRO_FEATURES = "cobalt-25"
+CONFLICT_DISTRO_FEATURES = "cobalt-24"
 
 require larboard_revision.inc
 require rdke-cobalt-buildfix.inc


### PR DESCRIPTION
RDK-59913 : Enabling Cobalt 25 as default distro in RDK-E
Reason for change: Enable Cobalt 25 as default distro in RDK E
Risks: Medium
Priority: P1