### PR TITLE
RDKEMW-10689: Adding T1 logging for ap_info_split details

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -19,7 +19,7 @@ S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=support/0.20.0"
 
-# Nov 14, 2025
+# Nov 20, 2025
 SRCREV = "782bee0bcb479b6d26947be3b01ee0708557dc03"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
RDKEMW-7459, RDKEMW-10336, RDKEMW-10689: Adding T1 logging for ap_info_split details

Reason for change: Added temporary log line for T1 to get ap_info details
Test Procedure: grep the "bssid=" in wpeframework.log
Priority:P1
Risks: Medium