### PR TITLE
RDKEMW-10728: Adding T1 logging for ap_info_split details

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "1.8.0"
+PV = "1.9.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-# Nov 14, 2025
-SRCREV = "60517027ac78237d2ce21ba020b5756af67ccc0a"
+# Nov 21, 2025
+SRCREV = "8c6ec3e7844751af886a19a1c2a8152d221ddb0c"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry iarmbus iarmmgrs ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', '', d)} "


### PR DESCRIPTION
RDKEMW-10728: Adding T1 logging for ap_info_split details

Reason for change: Added temporary log line for T1 to get ap_info details
Test Procedure: grep the "bssid=" in wpeframework.log
Priority:P1
Risks: Medium