### PR TITLE
RDKEMW-10577:Removed the direct log redirection to the console

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/1001-Disable-MessageDispatcher-Enable-stderr.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/1001-Disable-MessageDispatcher-Enable-stderr.patch
@@ -20,29 +20,6 @@ index 9dbff76a..4b5ba798 100644
      TRACE_FORMATTING_IMPL(fmt, ##__VA_ARGS__)
  #else
  #define TRACE_FORMATTING(fmt, ...)                                                                            \
-diff --git a/Source/messaging/MessageUnit.cpp b/Source/messaging/MessageUnit.cpp
-index be5f53f3..f2f48438 100644
---- a/Source/messaging/MessageUnit.cpp
-+++ b/Source/messaging/MessageUnit.cpp
-@@ -252,6 +252,10 @@ namespace WPEFramework {
-         */
-         /* virtual */ void MessageUnit::Push(const Core::Messaging::MessageInfo& messageInfo, const Core::Messaging::IEvent* message)
-         {
-+#if 1
-+            _direct.Mode(false, _settings.IsAbbreviated());
-+            _direct.Output(messageInfo, message);
-+#else
-             //logging messages can happen in Core, meaning, otherside plugin can be not started yet
-             //those should be just printed
-             if (_settings.IsDirect() == true) {
-@@ -278,6 +282,7 @@ namespace WPEFramework {
-                     TRACE_L1("Unable to push data, buffer is too small!");
-                 }
-             }
-+#endif
-         }
-     } // namespace Messaging
- }
 diff --git a/Source/core/MessageStore.cpp b/Source/core/MessageStore.cpp
 index 07e2e81e..f3bb695f 100644
 --- a/Source/core/MessageStore.cpp


### PR DESCRIPTION
RDKEMW-10577 : Removed the direct log redirection to the console 
Reason for change:  Remove the change that we have at Source/messaging/MessageUnit.cpp to print to stderr and get a build; let the Thunder run with -b itself and get the CPU
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1