### PR TITLE
RDKEMW-10940: wpe 2.38 Fix GST quirks autodetection

### DIFF
--- a/recipes-extended/wpe-webkit/files/2.38.8/1488_GST_Quirks_auto.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/1488_GST_Quirks_auto.patch
@@ -1,0 +1,168 @@
+From 8317652fbeef8bb3769dd81c942d3ac4056935fe Mon Sep 17 00:00:00 2001
+From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+Date: Fri, 4 Apr 2025 14:18:41 +0200
+Subject: [PATCH] [GStreamerQuirks] Add isPlatformSupported() impl
+
+Implement the isPlatformSupported() function by verifying
+the availability of the required GStreamer elements.
+Amlogic, Broadcom, Realtek and Westeros
+---
+ .../WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp | 5 +++++
+ .../WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h   | 1 +
+ .../platform/gstreamer/GStreamerQuirkBroadcom.cpp        | 5 +++++
+ .../WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h  | 1 +
+ .../WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp | 5 +++++
+ .../WebCore/platform/gstreamer/GStreamerQuirkRealtek.h   | 1 +
+ .../WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp  | 9 +++++++++
+ Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h | 1 +
+ .../platform/gstreamer/GStreamerQuirkWesteros.cpp        | 5 +++++
+ .../WebCore/platform/gstreamer/GStreamerQuirkWesteros.h  | 1 +
+ 10 files changed, 34 insertions(+)
+
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
+index 610f026e434d..9b27ad80bcc1 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
+@@ -36,6 +36,11 @@ GStreamerQuirkAmLogic::GStreamerQuirkAmLogic()
+     GST_DEBUG_CATEGORY_INIT(webkit_amlogic_quirks_debug, "webkitquirksamlogic", 0, "WebKit AmLogic Quirks");
+ }
+ 
++bool GStreamerQuirkAmLogic::isPlatformSupported() const
++{
++    return adoptGRef(gst_element_factory_find("amlhalasink"));
++}
++
+ GstElement* GStreamerQuirkAmLogic::createWebAudioSink()
+ {
+     // autoaudiosink changes child element state to READY internally in auto detection phase
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
+index 8643498a5492..73e80bf3997c 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
+@@ -30,6 +30,7 @@ class GStreamerQuirkAmLogic final : public GStreamerQuirk {
+ public:
+     GStreamerQuirkAmLogic();
+     const ASCIILiteral identifier() const final { return "AmLogic"_s; }
++    bool isPlatformSupported() const final;
+ 
+     GstElement* createWebAudioSink() final;
+     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+index 8bf195f4ab7a..5cdb5e0f7b75 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+@@ -37,6 +37,11 @@ GStreamerQuirkBroadcom::GStreamerQuirkBroadcom()
+     m_disallowedWebAudioDecoders = { "brcmaudfilter"_s };
+ }
+ 
++bool GStreamerQuirkBroadcom::isPlatformSupported() const
++{
++    return adoptGRef(gst_element_factory_find("brcmaudiosink"));
++}
++
+ void GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
+ {
+     if (!g_strcmp0(G_OBJECT_TYPE_NAME(element), "Gstbrcmaudiosink"))
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
+index b6e75b024e88..5d78e9d383ab 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
+@@ -32,6 +32,7 @@ class GStreamerQuirkBroadcom final : public GStreamerQuirkBroadcomBase {
+ public:
+     GStreamerQuirkBroadcom();
+     const ASCIILiteral identifier() const final { return "Broadcom"_s; }
++    bool isPlatformSupported() const final;
+ 
+     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+index 390df682013c..1e362752a1ae 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+@@ -47,6 +47,11 @@ GStreamerQuirkRealtek::GStreamerQuirkRealtek()
+     };
+ }
+ 
++bool GStreamerQuirkRealtek::isPlatformSupported() const
++{
++    return adoptGRef(gst_element_factory_find("rtkaudiosink"));
++}
++
+ GstElement* GStreamerQuirkRealtek::createWebAudioSink()
+ {
+     auto sink = makeGStreamerElement("rtkaudiosink", nullptr);
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
+index 98fdbae46bd3..3620f16f5301 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
+@@ -30,6 +30,7 @@ class GStreamerQuirkRealtek final : public GStreamerQuirk {
+ public:
+     GStreamerQuirkRealtek();
+     const ASCIILiteral identifier() const final { return "Realtek"_s; }
++    bool isPlatformSupported() const final;
+ 
+     GstElement* createWebAudioSink() final;
+     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+index bd3cd5184b89..2be808151522 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+@@ -68,6 +68,15 @@ GStreamerQuirkRialto::GStreamerQuirkRialto()
+     }
+ }
+ 
++bool GStreamerQuirkRialto::isPlatformSupported() const
++{
++    auto sinkFactory = adoptGRef(gst_element_factory_find("rialtomsevideosink"));
++    if (!sinkFactory)
++        return false;
++    auto rank = gst_plugin_feature_get_rank(GST_PLUGIN_FEATURE(sinkFactory.get()));
++    return rank > GST_RANK_MARGINAL;
++}
++
+ void GStreamerQuirkRialto::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>&)
+ {
+     if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstURIDecodeBin3")) {
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+index 2761c9297725..e945d89d4dfe 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+@@ -35,6 +35,7 @@ class GStreamerQuirkRialto final : public GStreamerQuirk {
+ public:
+     GStreamerQuirkRialto();
+     const ASCIILiteral identifier() const final { return "Rialto"_s; }
++    bool isPlatformSupported() const final;
+ 
+     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+     GstElement* createAudioSink() final;
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+index 0ef739ee4c56..16c443b00b32 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+@@ -51,6 +51,11 @@ GStreamerQuirkWesteros::GStreamerQuirkWesteros()
+     }
+ }
+ 
++bool GStreamerQuirkWesteros::isPlatformSupported() const
++{
++    return adoptGRef(gst_element_factory_find("westerossink"));
++}
++
+ void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
+ {
+     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
+index 1ea2119d7d2b..c524c6e9db02 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
+@@ -30,6 +30,7 @@ class GStreamerQuirkWesteros final : public GStreamerQuirk {
+ public:
+     GStreamerQuirkWesteros();
+     const ASCIILiteral identifier() const final { return "Westeros"_s; }
++    bool isPlatformSupported() const final;
+ 
+     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
+-- 
+2.45.2
+

--- a/recipes-extended/wpe-webkit/files/2.38.8/1583_GstQuirks_gst_init.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/1583_GstQuirks_gst_init.patch
@@ -1,0 +1,31 @@
+From 60d9e167a0ac7c9ae6812f78f8a5e20ea180c422 Mon Sep 17 00:00:00 2001
+From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+Date: Fri, 21 Nov 2025 12:35:50 +0100
+Subject: [PATCH] [GST] Ensure GST initialized before playing with GST Quirks
+
+GStreamerQuirksManager verifies each quirk with isPlatformSupported()
+that usually relies on gst elements presense in the registry.
+Calling this without gst_init called fails for every gst element
+and rejects all quirks.
+
+The problem exists for apps that don't use any of canPlayType()
+or isTypeSupported() that handle gst_init internally
+---
+ Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+index 3966414697a0..398d93a839fe 100644
+--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
++++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+@@ -55,6 +55,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
+ {
+     static std::once_flag debugRegisteredFlag;
+     std::call_once(debugRegisteredFlag, [] {
++        ensureGStreamerInitialized();
+         GST_DEBUG_CATEGORY_INIT(webkit_quirks_debug, "webkitquirks", 0, "WebKit Quirks");
+     });
+ 
+-- 
+2.51.0
+

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.38.8.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.38.8.bb
@@ -3,7 +3,7 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r11"
+PR  = "r12"
 
 # Temporary build fix
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
@@ -20,8 +20,6 @@ SRC_URI = "${BASE_URI}"
 SRC_URI += "file://2.38.2/1196.patch"
 SRC_URI += "file://2.38.6/1384.patch"
 SRC_URI += "file://2.38.7/1410.patch"
-SRC_URI += "file://2.38.8/1448_Added-API-to-get-and-set-screen-supports-HDR-setting.patch"
-SRC_URI += "file://2.38.8/1463_GStreamer-support-the-eotf-additional-MIME-type.patch"
 
 # Drop after issue is addressed and a corresponding PR is merged
 SRC_URI += "file://2.38.8/1456-RDKTV-35082-Workaround-premature-finishSeek.patch"
@@ -30,6 +28,10 @@ SRC_URI += "file://2.38.8/1456-RDKTV-35082-Workaround-premature-finishSeek.patch
 SRC_URI += "file://2.38.8/1423-revert.patch"
 SRC_URI += "file://2.38.8/1531.patch"
 SRC_URI += "file://2.38.8/cmake-Fix-recompilation-on-rebuild-without-changes.patch"
+SRC_URI += "file://2.38.8/1488_GST_Quirks_auto.patch"
+SRC_URI += "file://2.38.8/1583_GstQuirks_gst_init.patch"
+SRC_URI += "file://2.38.8/1448_Added-API-to-get-and-set-screen-supports-HDR-setting.patch"
+SRC_URI += "file://2.38.8/1463_GStreamer-support-the-eotf-additional-MIME-type.patch"
 SRC_URI += "file://2.38.8/1467.patch"
 
 # Drop after libwpe upgrade


### PR DESCRIPTION
RDKEMW-10940 : wpe 2.38 Fix GST quirks autodetection

Reason for change: Ensure GST initialized before using gst quirks
Test Procedure: See Jira ticket
Priority: P1
Risks: Low

Change-Id: Ife0030a34f0366738cdf5cd817d80dd7f182ae0a


GST Quirks auto for wpe 2.38

Reason for change: Autodetect GST quirks
Test Procedure: See Jira ticket
Priority: P1
Risks: None

Change-Id: I12ffc2e1c09859d0fd66bb27525d33c47c42465a