### PR TITLE
RDKEMW-11347 : Observing routerDiscovery@eth0.service in failed

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -19,7 +19,7 @@ S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=support/0.20.0"
 
-# Nov 20, 2025
+# Dec 8, 2025
 SRCREV = "8a486bfa7a5e061b13fa20bfa08e0dd91111a001"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
Reason for change: routerDiscovery exit code handled correctly.
Also only 1 instance of routerDiscovery should be active for an interface.
Test Procedure: Check the systemd status for routerDiscovery
Risks: Low
Signed-off-by: [jincysaramma_sam@comcast.com](mailto:jincysaramma_sam@comcast.com)