### PR TITLE
RDKEMW-11155: NetworkManager connectivity check endpoint configuratio…

### DIFF
--- a/recipes-extended/sysint/files/nm-connectivity.conf
+++ b/recipes-extended/sysint/files/nm-connectivity.conf
@@ -1,0 +1,5 @@
+[connectivity]
+enabled=true
+uri=http://example.com
+interval=2
+response=


### PR DESCRIPTION
…n (#2171)

* RDKEMW-11155: NetworkManager connectivity check endpoint configuration

Reason for change: Enable networkmanager connectivity check for RDK based devices. Adding default gnome networkmanager connectivity check endpoint url



* RDKEMW-11155: Update sysint

---------