### PR TITLE
RDKEMW-9249 - NetworkManager Plugin Release - 1.10.0 (#2266)

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,12 +14,12 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "1.9.0"
+PV = "v1.10.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-SRCREV = "8c6ec3e7844751af886a19a1c2a8152d221ddb0c"
+SRCREV = "12848984e5b6acb5dc3e049cecee9cb50efa4bbe"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry iarmbus iarmmgrs ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', '', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 1.10.0 with following Bug fixes
- Fixed the GetIPSettings for RDK Backend to return only when all the information like DNS info retrieved
- Fixed the retrieval of psk to pass it to MfrMgr.