### PR TITLE
RDKEMW-11468 : Add fallback xcast uuid from DeviceInfo.serialnumber

### DIFF
--- a/recipes-extended/entservices/entservices-casting.bb
+++ b/recipes-extended/entservices/entservices-casting.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-casting;${CMF_GITHUB_SRC_URI_SUFFIX} \
           "
 
 # Release version - 1.4.0
-SRCREV = "78478e1a0a59994b533a678dd0b01c3f8bf310bd"
+SRCREV = "cc264ff181631490847a577abcd401aff91b2157"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason For Change: ReceiverID is dependent on Auth service which is not open-sourced. Add fallback UUID v5 generation logic using Device's serial number which will be unique.