### PR TITLE
RDKEMW-11771 : NetworkManager Plugin Release - 1.12.0 (rebase)

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,12 +14,12 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "v1.11.0"
+PV = "v1.12.0"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
 
-SRCREV = "bfecfd9457e7365a8e7d83640307766315434a22"
+SRCREV = "7326cf227b110da6f45c234d3f97ad728ce6fc2b"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry iarmbus iarmmgrs ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', '', d)} "


### PR DESCRIPTION
Reason for change: Upgrade to new release - 1.12.0 with following Bug fixes
- Fixed the Ethernet interface enablement upon EntOS migration Test Procedure: Test with EPG changes