### PR TITLE
RDKEMW-12118:[BassboostTable] Modifications needed in iarmmgr to incl…

### DIFF
--- a/recipes-extended/iarmmgrs/files/0003-add_dsmgr_service_env_settings.patch
+++ b/recipes-extended/iarmmgrs/files/0003-add_dsmgr_service_env_settings.patch
@@ -12,7 +12,7 @@ Index: git/conf/dsmgr.service
  Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket
  Environment="XDG_RUNTIME_DIR=/tmp"
  Environment="HDMIIN_USE_ESSRMGR=1"
-+ExecStartPre=/bin/sh -c 'VOL_MAP_INI=`/usr/bin/panelIDConfig -v`;/bin/systemctl set-environment VOLUME_TABLE=$VOL_MAP_INI'
++ExecStartPre=/bin/sh -c 'DS_AUDIO_PARAM_MAP_INI=`/usr/bin/panelIDConfig -v`;/bin/systemctl set-environment DS_AUDIO_PARAM_MAP=$DS_AUDIO_PARAM_MAP_INI'
 +ExecStartPre=/bin/sh -c 'AUDIO_PROFILE_INI=`/usr/bin/panelIDConfig -r`;/bin/systemctl set-environment MS12_AUDIO_PROFILE=$AUDIO_PROFILE_INI'
  ExecStartPre=/bin/mkdir -p /opt/persistent/ds
  ExecStart=/usr/bin/dsMgrMain


### PR DESCRIPTION
…ude env variables

https://ccp.sys.comcast.net/browse/RDKEMW-12118
https://ccp.sys.comcast.net/browse/RDKEVD-4162
* since post_gain or sw_volume control is moved to ds_audio_param_map, removing redundant panelId option
* Modified patch file to export modified env.