### PR TITLE
RDKEMW-8587: consume the config variables using dlsym() in MW.

### DIFF
--- a/recipes-extended/devicesettings/devicesettings_git.bb
+++ b/recipes-extended/devicesettings/devicesettings_git.bb
@@ -5,9 +5,9 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PV = "1.0.25"
-PR = "r0"
+PR = "r1"
 
-SRCREV_devicesettings = "604ef1b6504c696a36b50310a27de2d31a19ec16"
+SRCREV_devicesettings = "b8cdf9991c6129ebbebf0434836fe6c563d5b257"
 SRC_URI = "${CMF_GITHUB_ROOT}/devicesettings;${CMF_GITHUB_SRC_URI_SUFFIX};name=devicesettings"
 
 # devicesettings is not a 'generic' component, as some of its source

--- a/recipes-extended/entservices/entservices-peripherals.bb
+++ b/recipes-extended/entservices/entservices-peripherals.bb
@@ -3,7 +3,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7e2eceb64cc374eafafd7e1a4e763f63"
 
 PV = "1.1.0"
-PR = "r0"
+PR = "r1"
 
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-peripherals;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.1.0
-SRCREV = "a31d0137fe375e9b5842f49c85f09cec66948810"
+# Release version - 1.1.1
+SRCREV = "808c4b06a1b89c93fc55c4e16ddff462ca685800"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: consume the config variables using dlsym() in MW and add device::Manager::Initialize() in FrontPanel. 
Test Procedure: refer RDKEMW-8587
Risks: High
Signed-off-by:gsanto722 <grandhi_santoshkumar@comcast.com>