### PR TITLE
RDKEMW-12226 : [RDKE] [Generic] Fix the double free issue in widevine…

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework-ocdm-playready-rdk_git.bb
+++ b/recipes-extended/wpe-framework/wpeframework-ocdm-playready-rdk_git.bb
@@ -22,7 +22,7 @@ TOOLCHAIN = "gcc"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 SRC_URI = "git://github.com/rdkcentral/playready-rdk.git;${CMF_GITHUB_SRC_URI_SUFFIX};name=pr-source"
-SRCREV = "fdb9d7bb172f90e1db0adb0f974c1a2d8a06911a"
+SRCREV = "1dbf957f4f6a7ce8a2708fa241c189a890fa6e58"
 SRCREV_FORMAT = "pr-source pr-header"
 S = "${WORKDIR}/git"
 

--- a/recipes-extended/wpe-framework/wpeframework-ocdm-widevine_git.bb
+++ b/recipes-extended/wpe-framework/wpeframework-ocdm-widevine_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=19a2b3c39737289f92c7991b16599360"
 include recipes-extended/wpe-framework/include/wpeframework-plugins.inc
 
 SRC_URI = "git://github.com/rdkcentral/widevine-rdk.git;${CMF_GITHUB_SRC_URI_SUFFIX}"
-SRCREV = "7fcbe276c8c93bf1093f55774c4e7d16c01d6738"
+SRCREV = "0f00ae523882e133e8f895f5c3fde067181946a5"
 
 # Platform configurations
 DEPENDS += " ${platform-widevine-depends}"


### PR DESCRIPTION
Reason for change: To avoid double free in Widevine Decrypt() failure case and to add PR support on BCM74110.
Test Procedure: Verify the build and WV/PR playback.
Risks: None.

Signed-off-by: thenmozhi_kathiravan@comcast.com