### PR TITLE
RDKEMW-12247 : Avoid Loading Plugin's MetaData On Thunder Startup

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/RDKEMW-8889-Avoid-LoadMeta-On-Boot.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/RDKEMW-8889-Avoid-LoadMeta-On-Boot.patch
@@ -1,0 +1,20 @@
+diff --git a/Source/WPEFramework/PluginServer.cpp b/Source/WPEFramework/PluginServer.cpp
+index 650a2e1d..2a2cf9a9 100644
+--- a/Source/WPEFramework/PluginServer.cpp
++++ b/Source/WPEFramework/PluginServer.cpp
+@@ -1093,6 +1093,7 @@ POP_WARNING()
+         std::vector<PluginHost::ISubSystem::subsystem> externallyControlled;
+         ServiceMap::Iterator iterator(_services.Services());
+
++#if 0
+         // Load the metadata for the subsystem information..
+         while (iterator.Next() == true)
+         {
+@@ -1111,6 +1112,7 @@ POP_WARNING()
+                 }
+             }
+         }
++#endif
+
+         _controller->Activate(PluginHost::IShell::STARTUP);
+

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -64,6 +64,7 @@ SRC_URI += "file://r4.4/PR-1369-Wait-for-Open-in-Communication-Channel.patch \
             file://r4.4/PR-1923-RDKEMW-6261-to-improve-system-shutdown-time-upon-R4.4.3.patch \
             file://r4.4/rdkemw-124-Link-Breakpad-wrapper.patch \
             file://r4.4/Revert_PR-665_support_JSON_Parsing.patch \
+            file://r4.4/RDKEMW-8889-Avoid-LoadMeta-On-Boot.patch \
            "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change: Since RDK is using Systemd Based activation of Plugins, we do not need Thunder to populate metadata on startup.
Test Procedure: Successful activation of Plugins on Reboot test; Also test FSR to ensure the OCDM is properly activated in both Pre & Post
Risks: Low