### PR TITLE
RDKEMW-12433: Remove export of `westeros-env` from Thunder systemd Service

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
+++ b/recipes-extended/wpe-framework/wpeframework/wpeframework.service.in
@@ -6,7 +6,6 @@ RequiresMountsFor=/opt/secure
 
 [Service]
 Type=notify
-EnvironmentFile=-/etc/default/westeros-env
 Environment="LD_LIBRARY_PATH=/usr/lib:/media/apps/netflix/usr/lib:/tmp/netflix/usr/lib:/media/apps/libcobalt/usr/lib:/tmp/libcobalt/usr/lib:/usr/lib/javascriptcore"
 Environment="XDG_RUNTIME_DIR=/tmp"
 Environment="GST_REGISTRY=/opt/.gstreamer/registry.bin"


### PR DESCRIPTION
Reason for change: westeros-env` is used by RDKSHELL in RDKV , now RDKSHELL is removed from RDKE and this westeros-env` is not required anymore
Test Procedure: please refer the ticket comments
Risks: Medium