### PR TITLE
RDKEMW-12440::Fix for crash on miracast controller

### DIFF
--- a/recipes-extended/entservices/entservices-casting.bb
+++ b/recipes-extended/entservices/entservices-casting.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices Casting plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=be469927b9722d71bc41ecd5e71fe35f"
 
-PV ?= "1.2.2"
+PV ?= "1.2.6-hotfix.1"
 PR ?= "r1"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-casting;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.2.6
-SRCREV = "f0bc49771b0c0549a3b696ecd7bd3f1360a58590"
+# Release version - 1.2.6-hotfix.1
+SRCREV = "83dd824a2f8425c1b31d5e1a4fffb69afb9ba7f0"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason For Change: Fix for crash on miracast controller
Test procedure : Compiled and Verified
version: minor
Priority: P1