### PR TITLE
RDKEMW-12488: StorageManager Error cases in configure method should clear the interface pointers

### DIFF
--- a/recipes-extended/entservices/entservices-rdkappmanagers.bb
+++ b/recipes-extended/entservices/entservices-rdkappmanagers.bb
@@ -8,7 +8,7 @@ PR ?= "r0"
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
-SRCREV = "93def6cc2abc294dcf6850210660433aa801bf61"
+SRCREV = "42d73f838cc43e8615528796e3441020d43a5803"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-appmanagers;${CMF_GITHUB_SRC_URI_SUFFIX}"
 


### PR DESCRIPTION
Reason for change: In configure method, interface pointer should be released otherwise, it will lead to memory leak.
Version: Minor
Test Procedure: None
Priority: P2
Risks: None
Signed-off-by: [Jeyasona_Durairaj@comcast.com]