### PR TITLE
RDKEMW-12632: Apparmor denied logs observed for name="/etc/log4crc" after CDL

### DIFF
--- a/recipes-mac/apparmor/apparmor-generic.bb
+++ b/recipes-mac/apparmor/apparmor-generic.bb
@@ -3,7 +3,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://rdk-apparmor-profiles/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 PV = "2.0.0"
-PR = "r0"
+PR = "r1"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 inherit pkgconfig autotools systemd


### PR DESCRIPTION
Reason for change: Fixing the DENIED log with respective resource and access permission
Test Procedure: DENIED logs shouldn't appear
Risks: Medium
Priority: P0