### PR TITLE
SERXIONE-8263: wpe-2.46 Add possibility to build webkit with cairo

### DIFF
--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
@@ -106,6 +106,7 @@ PACKAGECONFIG[westeros]     = ""
 PACKAGECONFIG:append = " webdriver remoteinspector releaselog accessibility speechsynthesis native_video webaudio woff2 externalholepunch"
 PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'malloc_heap_breakdown', 'malloc_heap_breakdown', '', d)}"
 PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'wpe-webkit-developer-mode', 'developermode tools', '', d)}"
+PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'wpe-webkit-cairo', 'cairo', '', d)}"
 PACKAGECONFIG:append = " ${@bb.utils.contains('BROWSER_MEMORYPROFILE', 'fhd', 'fhd', '', d)}"
 
 PACKAGECONFIG:append:aarch64 = " webassembly"


### PR DESCRIPTION
Reason for change: Add wpe-webkit-cairo distro feature that forces using cairo backend instead of skia
Test Procedure: Dev option only - disabled by default Priority: P1
Risks: None - disabled

Change-Id: If8224fb64f2e770231b778ca2a7cfa1e9ee15711