### PR TITLE
RDKEMW-9893: enable new dtags (RUNPATH instead of RPATH) for webkit b…

### DIFF
--- a/recipes-extended/wpe-webkit/wpe-webkit.inc
+++ b/recipes-extended/wpe-webkit/wpe-webkit.inc
@@ -157,3 +157,7 @@ do_install:append() {
        (cd ${B}; find . -name '*.dwo' -print0 | tar -czvf ${D}/usr/src/debug/${PN}-dwo.tgz --null -T -)
     fi
 }
+
+WPE_LIB_RUNPATH ?= "\$ORIGIN/../../lib"
+EXTRA_OECMAKE:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'wpe_webkit_enable_new_dtags_runpath', ' -DCMAKE_INSTALL_RPATH=${WPE_LIB_RUNPATH} -DDISABLE_NEW_DTAGS=OFF', '', d)}"
+SYSROOT_DIRS:append = " ${libexecdir}"


### PR DESCRIPTION
Enable new dtags in WebKit build for WPEWebProcess with RUNPATH

Added support for embedding RUNPATH into WPEWebProcess if the 
`wpe_webkit_enable_new_dtags_runpath` distro flag is defined. This 
change ensures that the correct library search path is set at runtime.