### PR TITLE
RDKEMW-6483: Disable startup of Analytics thunder plugin

### DIFF
--- a/recipes-extended/thunderstartupservices/thunderstartupservices.bb
+++ b/recipes-extended/thunderstartupservices/thunderstartupservices.bb
@@ -40,7 +40,6 @@ THUNDER_STARTUP_SERVICES:append = "\
     wpeframework-voicecontrol.service \
     wpeframework-wifi.service \
     wpeframework-xcast.service \
-    wpeframework-analytics.service \
     wpeframework-usersettings.service \
     wpeframework-usbdevice.service \
     wpeframework-usbmassstorage.service \


### PR DESCRIPTION
In 8.3.4.0 the Analytics plugin is not used
and not operational. We are disabling to prevent from crashing scenario