### PR TITLE
RDKEMW-12975: Remove Duplicate Files Found for NetworkManager

### DIFF
--- a/recipes-extended/rialto/rialto_git.bb
+++ b/recipes-extended/rialto/rialto_git.bb
@@ -16,7 +16,7 @@ PR = "r0"
 
 require rialto_revision.inc
 
-SRCREV = "c22c4beb5451c7ba642c3969ed87b6638323607b"
+SRCREV = "4d930b26289dd6b5d3e3dfa0b877a9a9d2d38e74"
 SRC_URI = "${CMF_GITHUB_ROOT}/rialto;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH}"
 SRC_URI += "file://0001-link-rdkgstreamerutilsplatform.patch"
 


### PR DESCRIPTION
Reason for change: dnsmasq-dobby.conf is already installed to /etc/NetworkManager/ path.
Remove it from /etc/ since sysint installs all conf files to /etc by default.
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)