### PR TITLE
RDKEMW-12989 : PluginActivation to not to check the PID while Activate/Deactivate request

### DIFF
--- a/recipes-extended/thunder-plugin-activator/thunder-plugin-activator.bb
+++ b/recipes-extended/thunder-plugin-activator/thunder-plugin-activator.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = "cmake-native wpeframework-tools-native wpeframework"
 
-PV = "1.1.0"
+PV = "1.2.0"
 PR = "r0"
 
 SRC_URI = "git://github.com/rdkcentral/ThunderPluginActivator;protocol=https;branch=main;name=thunderpluginactivator"


### PR DESCRIPTION
Reason for change: Removed the Thunder/WPEFramework running check before activate /deactivate request
Test Procedure: please refer the ticket comments
Risks: Medium