### PR TITLE
RDKEMW-12964: Move PV, PR, PACKAGE_ARCH to individual recipes

### DIFF
--- a/recipes-extended/firebolt-cpp-client/firebolt-cpp-client.bb
+++ b/recipes-extended/firebolt-cpp-client/firebolt-cpp-client.bb
@@ -6,11 +6,13 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 inherit cmake
 
-PV ?= "v0.2.2"
-FIREBOLT_CPP_CLIENT_SHA256 ?= "10681a6c5ad7274d05cb713ca267aaad70ca92057166b1733400d71353edef38"
+PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
+
+PV = "0.2.2"
+PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-client/releases/download/v${PV}/firebolt-cpp-client-${PV}.tar.gz"
-SRC_URI[sha256sum] = "${FIREBOLT_CPP_CLIENT_SHA256}"
+SRC_URI[sha256sum] = "10681a6c5ad7274d05cb713ca267aaad70ca92057166b1733400d71353edef38"
 
 S = "${WORKDIR}/firebolt-cpp-client-${PV}"
 

--- a/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
+++ b/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
@@ -6,11 +6,13 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 inherit cmake
 
-PV ?= "v1.0.0"
-FIREBOLT_CPP_TRANSPORT_SHA256 ?= "2ff666c266ec22f9ed7989b1c4d3a7c6c2df24a8880d8587179236ccfac24163"
+PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
+
+PV = "1.0.0"
+PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-transport/releases/download/v${PV}/firebolt-cpp-transport-${PV}.tar.gz"
-SRC_URI[sha256sum] = "${FIREBOLT_CPP_TRANSPORT_SHA256}"
+SRC_URI[sha256sum] = "2ff666c266ec22f9ed7989b1c4d3a7c6c2df24a8880d8587179236ccfac24163"
 
 S = "${WORKDIR}/firebolt-cpp-transport-${PV}"
 


### PR DESCRIPTION
RDKEMW-12964 : Move PV, PR, PACKAGE_ARCH to individual recipes
Reason for change: Move PV, PR closer to recipes

Test Procedure: Build the image

Risks: None