### PR TITLE
RDKEMW-13268: AAMP Federated Release for Sprint 2601 : Tag 3.2.0

### DIFF
--- a/recipes-extended/aamp/aamp_git.bb
+++ b/recipes-extended/aamp/aamp_git.bb
@@ -3,11 +3,11 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=97dd37dbf35103376811825b038fc32b"
 
-PV ?= "3.1.0"
+PV ?= "3.2.0"
 PR ?= "r0"
 
 SRCREV_FORMAT = "aamp"
-SRCREV_aamp ?= "acad51d6017f06100667e53a4c379ecd7483803d"
+SRCREV_aamp ?= "95b4505900ae43d96f530c030801a45459ef437b"
 
 DEPENDS += "curl libdash libxml2 cjson readline ${@bb.utils.contains('DISTRO_FEATURES', 'build_external_player_interface', 'player-interface', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'webkitbrowser-plugin', '${WPEWEBKIT}', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'subtec', 'closedcaption-hal-headers virtual/vendor-dvb virtual/vendor-closedcaption-hal', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'enable_rialto', 'dobby', '', d)}"
 


### PR DESCRIPTION
Reason for change: Update AAMP Commit SHA to 2601 sprint & TAG to 3.2.0