### PR TITLE
RDKEMW-13303: Adding AAMP NG build support in aamp meta layer

### DIFF
--- a/recipes-extended/aamp/aamp_git.bb
+++ b/recipes-extended/aamp/aamp_git.bb
@@ -7,7 +7,7 @@ PV ?= "2.11.1"
 PR ?= "r0"
 
 SRCREV_FORMAT = "aamp"
-SRCREV_aamp ?= "d8f156574d4abf8be5dcc3bb75b190536b74e6e8"
+SRCREV_aamp ?= "143af51c123baf07221eda04c1940b3d994ac78d"
 
 inherit pkgconfig
 


### PR DESCRIPTION
Non-functional change to support AAMP revision override which is required for AAMP NG build generation