### PR TITLE
RDKEMW-13150 : UserSetings Plugin Activation failed due to Plugin Activator

### DIFF
--- a/recipes-extended/thunder-plugin-activator/thunder-plugin-activator.bb
+++ b/recipes-extended/thunder-plugin-activator/thunder-plugin-activator.bb
@@ -6,12 +6,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = "cmake-native wpeframework-tools-native wpeframework"
 
-PV = "1.1.0"
+PV = "1.2.0"
 PR = "r0"
 
 SRC_URI = "git://github.com/rdkcentral/ThunderPluginActivator;protocol=https;branch=main;name=thunderpluginactivator"
 
-SRCREV = "1f0fd5618965b72850906f96762ec9f5f5704517"
+SRCREV = "545eafe42509a9e441408268df1e02c9da590329"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change: Removed the Thunde/WPEFramework running check before activate /deactivate request
Test Procedure: please refer the ticket comments
Risks: Medium
Signed-off-by: Thamim Razith Abbas Ali <tabbas651@cable.comcast.com>