### PR TITLE
RDKEMW-13117: Use IARM for PowerManager clients which uses PowerController ThunderClientLibrary

### DIFF
--- a/recipes-common/systimemgr/systimemgrfactory_git.bbappend
+++ b/recipes-common/systimemgr/systimemgrfactory_git.bbappend
@@ -1,6 +1,6 @@
 CXXFLAGS += " -I${PKG_CONFIG_SYSROOT_DIR}/${includedir}/rdk/iarmbus"
 
-EXTRA_OECONF:append = " --enable-iarm --enable-pwrmgrplugin --enable-debug"
+EXTRA_OECONF:append = " --enable-iarm --enable-debug"
 
 EXTRA_OECONF += "${@bb.utils.contains('DISTRO_FEATURES', 'tee_enabled', '--enable-tee', '', d)}"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'tee_enabled', 'virtual/tee', '', d)}"


### PR DESCRIPTION
RDKEMW-13117: Use IARM for PowerManager clients which uses PowerController ThunderClientLibrary

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>