### PR TITLE
RDKEMW-13057: Adding proper IARMBus dependency during buildtime

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices deviceanddisplay plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dc6e390ad71aef79d0c2caf3cde03a19"
 
-PV ?= "3.1.17-hotfix.2"
+PV ?= "3.1.17-hotfix.3"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 3.1.17-hotfix.2
-SRCREV = "76d3f71a9224c90217eddf5dc3464952a04c1886"
+# Release version - 3.1.17-hotfix.3
+SRCREV = "465dfa5ec4b95c8414223a8a2cf40201a143501c"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
RDKEMW-13057: Adding proper IARMBus dependency during buildtime

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>