### PR TITLE
RDKEMW-12934: Integrate entservices-inputoutput repos to middleware builds

### DIFF
--- a/recipes-extended/entservices/entservices-avinput.bb
+++ b/recipes-extended/entservices/entservices-avinput.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-avinput;${CMF_GITHUB_SRC_URI_SUFFIX} \
           "
 
 # Release version - 1.0.1
-SRCREV = "31645e13903539b038e8819867acaa10aaec4ab8"
+SRCREV = "266ab24064c67552623f9295eb71f4b936bf7dad"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-hdcpprofile.bb
+++ b/recipes-extended/entservices/entservices-hdcpprofile.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-hdcpprofile;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.0.1
-SRCREV = "22a2d295c7fa8410f400e4b8e987e3e7bc1fd914"
+SRCREV = "cbd04e83537831de0a863e8c01151e25961625a9"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-hdmicecsink.bb
+++ b/recipes-extended/entservices/entservices-hdmicecsink.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-hdmicecsink;${CMF_GITHUB_SRC_URI_SUFFI
           "
 
 # Release version - 1.0.1
-SRCREV = "5d18e1177793b0622cefcedfd0520ed8d9665280"
+SRCREV = "71f3d57b70b414a9a7843067b2d359eb2fb83da4"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-hdmicecsource.bb
+++ b/recipes-extended/entservices/entservices-hdmicecsource.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-hdmicecsource;${CMF_GITHUB_SRC_URI_SUF
           "
 
 # Release version - 1.0.1
-SRCREV = "9eece93f1dd428bac37a81f6bb199b7e82b79102"
+SRCREV = "240d00ada9e8c32cf5a10521bfee1dbdc44795db"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason For Change: Integrated the entservices-avinput to middleware builds
Test procedure : Compiled and Verified
Risks: Low
Priority: P2
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]"