### PR TITLE
RDKEMW-13676: Upgrade larboard to version 1.0.4

### DIFF
--- a/recipes-extended/cobalt/larboard_revision.inc
+++ b/recipes-extended/cobalt/larboard_revision.inc
@@ -3,5 +3,5 @@ LARBOARD_SRC_URI = "${CMF_GITHUB_ROOT}/larboard"
 # 24.lts.stable. March 13, 2025
 LARBOARD_SRCREV_24 ?= "10f8d522b8a26727bc03dfe1e3f619bad91df5c3"
 
-# develop. Nov 26, 2025
-LARBOARD_SRCREV_DEV ?= "1.0.3"
+# develop. Feb 08, 2025
+LARBOARD_SRCREV_DEV ?= "1.0.4"


### PR DESCRIPTION
1.Live DRM - freeze issue fix -Throttling audio write duration and playback position queries 2.Dual DRM - Added decrypt-to-host signaling in GStreamer caps 3.NPLB - Crash fix: skip AddColorMetadataToGstCaps for low bit-depth content 4.General pipeline setup improvements