### PR TITLE
RDKTV-39688: Fix RAM/swap reporting to use sysinfo mem_unit scaling

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/RDKTV-39688_apply_sysinfo_mem_unit.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/RDKTV-39688_apply_sysinfo_mem_unit.patch
@@ -1,0 +1,22 @@
+diff --git a/Source/core/SystemInfo.cpp b/Source/core/SystemInfo.cpp
+index de6705fe..35d2f546 100644
+--- a/Source/core/SystemInfo.cpp
++++ b/Source/core/SystemInfo.cpp
+@@ -167,12 +167,13 @@ namespace Core {
+         struct sysinfo info;
+         sysinfo(&info);
+ 
++        const uint64_t unit = (info.mem_unit != 0) ? info.mem_unit : 1;
+         m_uptime = info.uptime;
+-        m_totalram = info.totalram;
++        m_totalram = info.totalram * unit;
+         m_pageSize = static_cast<uint32_t>(sysconf(_SC_PAGESIZE));
+-        m_freeram = info.freeram;
+-        m_totalswap = info.totalswap;
+-        m_freeswap = info.freeswap;
++        m_freeram = info.freeram * unit;
++        m_totalswap = info.totalswap * unit;
++        m_freeswap = info.freeswap * unit;
+         m_cpuloadavg[0]=info.loads[0];
+         m_cpuloadavg[1]=info.loads[1];
+         m_cpuloadavg[2]=info.loads[2];


### PR DESCRIPTION
RDKTV-39688: Correct Linux RAM and swap reporting by applying sysinfo mem_unit scaling