### PR TITLE
RDKEMW-13687 : Increase Timeout for NTP PartnerURL Read

### DIFF
--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0 & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f36198fb804ffbe39b5b2c336ceef9f8"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
-PV = "4.3.0"
+PV = "4.3.1"
 PR = "r0"
 
 SRCREV = "4a29ec2760d7193648d01f47dde641db4c24b3ff"


### PR DESCRIPTION
Reason for Change : Update Latest sysint release 
Test Procedure: Validate NTP client behaviour. Results are captured in the ticket
Risks: Low
Priority: P1
Signed-off-by: Sindhuja [Sindhuja_Muthukrishnan@comcast.com](mailto:Sindhuja_Muthukrishnan@comcast.com)