### PR TITLE
ES1-2957: Fix Voice Guidance enabled via quick access menu

### DIFF
--- a/recipes-extended/wpe-webkit/files/2.46/comcast-RDK-56287-rdkat-atspi2.patch
+++ b/recipes-extended/wpe-webkit/files/2.46/comcast-RDK-56287-rdkat-atspi2.patch
@@ -1,6 +1,6 @@
-From 3058f828ba49733c85c12985c691647b5cbd3f5c Mon Sep 17 00:00:00 2001
-From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
-Date: Tue, 10 Jun 2025 09:25:51 +0200
+From 5282423102fb8d153dd39f913fd949e621d7c4d6 Mon Sep 17 00:00:00 2001
+From: Filipe Norte <filipe_norte@comcast.com>
+Date: Wed, 11 Feb 2026 09:41:07 +0000
 Subject: [PATCH] comcast - RDK-56287 - TTS support using AT-SPI2
 
 ATK support removed from newer wpe-webkit version
@@ -8,8 +8,10 @@ ATK support removed from newer wpe-webkit version
 Signed-off-by: Filipe Norte <filipe_norte@comcast.com>
 ---
  Source/WebCore/PlatformWPE.cmake                 |  4 ++++
- Source/WebKit/WebProcess/glib/WebProcessGLib.cpp | 14 +++++++++++++-
- 2 files changed, 17 insertions(+), 1 deletion(-)
+ .../accessibility/atspi/AccessibilityAtspi.cpp   |  7 ++++---
+ .../accessibility/atspi/AccessibilityAtspi.h     |  1 +
+ Source/WebKit/WebProcess/glib/WebProcessGLib.cpp | 16 +++++++++++++++-
+ 4 files changed, 24 insertions(+), 4 deletions(-)
 
 diff --git a/Source/WebCore/PlatformWPE.cmake b/Source/WebCore/PlatformWPE.cmake
 index d133eae89473..f4c115a561d1 100644
@@ -26,8 +28,50 @@ index d133eae89473..f4c115a561d1 100644
  if (USE_ATSPI)
      set(WebCore_AtspiInterfaceFiles
          ${WEBCORE_DIR}/accessibility/atspi/xml/Accessible.xml
+diff --git a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+index 636ac222fde3..e46020245749 100644
+--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
++++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+@@ -75,14 +75,14 @@ void AccessibilityAtspi::connect(const String& busAddress, const String& busName
+ 
+ void AccessibilityAtspi::didConnect(GRefPtr<GDBusConnection>&& connection)
+ {
+-    m_connection = WTFMove(connection);
+-    if (!m_connection) {
++    m_pendingConnection = WTFMove(connection);
++    if (!m_pendingConnection) {
+         m_isConnecting = false;
+         return;
+     }
+ 
+     RELEASE_ASSERT(g_dbus_is_name(m_busName.utf8().data()));
+-    g_bus_own_name_on_connection(m_connection.get(), m_busName.utf8().data(), G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
++    g_bus_own_name_on_connection(m_pendingConnection.get(), m_busName.utf8().data(), G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
+         [](GDBusConnection*, const char*, gpointer userData) {
+             auto& atspi = *static_cast<AccessibilityAtspi*>(userData);
+             atspi.didOwnName();
+@@ -93,6 +93,7 @@ void AccessibilityAtspi::didConnect(GRefPtr<GDBusConnection>&& connection)
+ void AccessibilityAtspi::didOwnName()
+ {
+     m_isConnecting = false;
++    m_connection = WTFMove(m_pendingConnection);
+ 
+     for (auto& pendingRegistration : m_pendingRootRegistrations)
+         registerRoot(pendingRegistration.root, WTFMove(pendingRegistration.interfaces), WTFMove(pendingRegistration.completionHandler));
+diff --git a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+index 6266eb09b0a8..f15d872042b8 100644
+--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
++++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+@@ -132,6 +132,7 @@ private:
+     String m_busName;
+     bool m_isConnecting { false };
+     GRefPtr<GDBusConnection> m_connection;
++    GRefPtr<GDBusConnection> m_pendingConnection;
+     GRefPtr<GDBusProxy> m_registry;
+     Vector<PendingRootRegistration> m_pendingRootRegistrations;
+     HashMap<CString, Vector<GUniquePtr<char*>>> m_eventListeners;
 diff --git a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
-index ff543f944a32..03502c6b565c 100644
+index ff543f944a32..50399c5d9b0e 100644
 --- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
 +++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
 @@ -100,6 +100,10 @@
@@ -41,13 +85,15 @@ index ff543f944a32..03502c6b565c 100644
  #define RELEASE_LOG_SESSION_ID (m_sessionID ? m_sessionID->toUInt64() : 0)
  #define WEBPROCESS_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
  #define WEBPROCESS_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
-@@ -231,7 +235,15 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
+@@ -231,7 +235,17 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
  #endif
  
  #if USE(ATSPI)
 -    AccessibilityAtspi::singleton().connect(parameters.accessibilityBusAddress, parameters.accessibilityBusName);
 +    // Enable RDKAT to process WebKit event into real speach (if TTS enabled)
 +    WTFLogAlways("Enable RDKAT processing for WPE");
++
++    WebCore::AXObjectCache::enableAccessibility();
 +
 +    const char * address = RDKAT_Initialize();
 +
@@ -59,5 +105,5 @@ index ff543f944a32..03502c6b565c 100644
  
      if (parameters.disableFontHintingForTesting)
 -- 
-2.48.1
+2.43.0
 

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
@@ -7,7 +7,7 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r28"
+PR  = "r29"
 
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
 DEPENDS:append = " libtasn1 unifdef-native libsoup libepoxy libgcrypt fontconfig"


### PR DESCRIPTION
Reason for chagne: When starting the browser with voice guidance disabled, enabling it afterward via quick access menu (without effectively leaving the browser) does not enable accessibility cache in browser without a page reload, which causes voice guidance to not be heard. Test Procedure: See ticket
Priority: P1
Risks: Low

Note: On 2.38, accessibility is enabled by default, so this brings us on par with it. However, since 2.46 uses ATSPI2, the premature enable may cause a crash due a race condition between webkit taking ownership of a requested bus name and attempts to register objects on webkit side due state changes. This is resolved by setting the connection only after the bus name is acquired, as calls are automatically protected. This issue does not exist if the accessibility is not enabled at startup, as by default it would only be enabled when a client connects, which happens only after the ATSPI stack is properly initialized.