### PR TITLE
RDKEMW-12252: Fixing RDKNativeScript Coverity Issues

### DIFF
--- a/recipes-graphics/rdknativescript/rdknativescript_git.bb
+++ b/recipes-graphics/rdknativescript/rdknativescript_git.bb
@@ -13,13 +13,13 @@ inherit cmake pkgconfig perlnative ${@bb.utils.contains("DISTRO_FEATURES", "kirk
 
 S = "${WORKDIR}/git"
 
-PV = "2.0.1"
+PV = "2.0.2"
 PR = "r0"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/rdkNativeScript;${CMF_GITHUB_SRC_URI_SUFFIX};"
 
-#Release 2.0.1
-SRCREV = "fd658c7612f006e384946f167db03caf454ab399"
+#Release 2.0.2
+SRCREV = "e9292baafbdcf46250cdb8ba3cec6566be9509fe"
 
 OECMAKE_GENERATOR = "Ninja"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
Reason for change: Release 2.0.2
Test Procedure: build should be successful
Risk: low
Priority: P2