### PR TITLE
RDKEMW-9893: Pass RUNPATH $ORIGIN:$ORIGIN../../lib to webkit.

### DIFF
--- a/recipes-extended/wpe-webkit/files/2.38.8/1605_Enable-new-dtags_flags-in-wpe-webkit.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/1605_Enable-new-dtags_flags-in-wpe-webkit.patch
@@ -1,0 +1,45 @@
+From 2047ee4cb6adf1d8f1c68c30dce4bc1c07fc1764 Mon Sep 17 00:00:00 2001
+From: Darko Lulic <Darko_Lulic@comcast.com>
+Date: Wed, 21 Jan 2026 15:10:09 +0000
+Subject: [PATCH] RDKEMW-9893: set option to enable new dtags.
+
+---
+ Source/cmake/OptionsCommon.cmake | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/Source/cmake/OptionsCommon.cmake b/Source/cmake/OptionsCommon.cmake
+index 98a65ac0a0c84..e742570346936 100644
+--- a/Source/cmake/OptionsCommon.cmake
++++ b/Source/cmake/OptionsCommon.cmake
+@@ -71,6 +71,15 @@ else ()
+     set(LD_SUPPORTS_THIN_ARCHIVES FALSE)
+     set(LD_SUPPORTS_DISABLE_NEW_DTAGS FALSE)
+ endif ()
++
++if (LD_SUPPORTS_DISABLE_NEW_DTAGS)
++    set(DISABLE_NEW_DTAGS_DEFAULT ON)
++else ()
++    set(DISABLE_NEW_DTAGS_DEFAULT OFF)
++endif ()
++
++option(DISABLE_NEW_DTAGS "Disable new dtags" ${DISABLE_NEW_DTAGS_DEFAULT})
++
+ unset(LD_VERSION)
+ message(STATUS "Linker variant in use: ${LD_VARIANT} ")
+ message(STATUS "  Linker supports thin archives - ${LD_SUPPORTS_THIN_ARCHIVES}")
+@@ -112,10 +121,14 @@ message(STATUS "  Archiver supports thin archives - ${AR_SUPPORTS_THIN_ARCHIVES}
+ # passing the option DT_RUNPATH is used, which can be overriden by the value
+ # of LD_LIBRARY_PATH set in the environment, resulting in unexpected behaviour
+ # for developers.
+-if (LD_SUPPORTS_DISABLE_NEW_DTAGS)
++if (DISABLE_NEW_DTAGS)
+     string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--disable-new-dtags")
+     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--disable-new-dtags")
+     string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--disable-new-dtags")
++else ()
++    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--enable-new-dtags")
++    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--enable-new-dtags")
++    string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--enable-new-dtags")
+ endif ()
+ 
+ # Prefer thin archives by default if they can be both created by the

--- a/recipes-extended/wpe-webkit/files/2.38.8/1611_Load-libWPEWebInspectorResources-from-widget.patch
+++ b/recipes-extended/wpe-webkit/files/2.38.8/1611_Load-libWPEWebInspectorResources-from-widget.patch
@@ -1,0 +1,30 @@
+From 69ce745c25f2aaa7d8720969a72cdf4dcbed0137 Mon Sep 17 00:00:00 2001
+From: Darko Lulic <Darko_Lulic@comcast.com>
+Date: Thu, 5 Feb 2026 10:23:54 +0000
+Subject: [PATCH] RDKEMW-9893: Load libWPEWebInspectorResources from launcher
+ widget.
+
+---
+ .../inspector/remote/glib/RemoteInspectorUtils.cpp       | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp
+index 31ff5ac70c112..ecf052bed3155 100644
+--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp
++++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp
+@@ -43,7 +43,14 @@ GRefPtr<GBytes> backendCommands()
+     static bool moduleLoaded = false;
+ 
+     if (!moduleLoaded) {
+-        GModule* resourcesModule = g_module_open(PKGLIBDIR G_DIR_SEPARATOR_S "libWPEWebInspectorResources.so", G_MODULE_BIND_LAZY);
++        const char* libDir = PKGLIBDIR;
++        GUniquePtr<char> tmp;
++        if (const char* path = g_getenv("WEBKIT_INJECTED_BUNDLE_PATH"); path && g_file_test(path, G_FILE_TEST_IS_DIR)) {
++            tmp.reset(g_build_filename(path, "..", nullptr));
++            libDir = tmp.get();
++        }
++        GUniquePtr<char> bundleFilename(g_build_filename(libDir, "libWPEWebInspectorResources.so", nullptr));
++        GModule* resourcesModule = g_module_open(bundleFilename.get(), G_MODULE_BIND_LAZY);
+         if (!resourcesModule) {
+             WTFLogAlways("Error loading libWPEWebInspectorResources.so: %s", g_module_error());
+             return nullptr;

--- a/recipes-extended/wpe-webkit/wpe-webkit.inc
+++ b/recipes-extended/wpe-webkit/wpe-webkit.inc
@@ -157,3 +157,7 @@ do_install:append() {
        (cd ${B}; find . -name '*.dwo' -print0 | tar -czvf ${D}/usr/src/debug/${PN}-dwo.tgz --null -T -)
     fi
 }
+
+WPE_LIB_RUNPATH ?= "\$ORIGIN:\$ORIGIN/../../lib"
+EXTRA_OECMAKE:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'wpe-webkit-enable-new-dtags-runpath', ' -DCMAKE_INSTALL_RPATH=${WPE_LIB_RUNPATH} -DDISABLE_NEW_DTAGS=OFF', '', d)}"
+SYSROOT_DIRS:append = " ${libexecdir}"

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.38.8.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.38.8.bb
@@ -3,7 +3,7 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r13"
+PR  = "r14"
 
 # Temporary build fix
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
@@ -34,6 +34,8 @@ SRC_URI += "file://2.38.8/1448_Added-API-to-get-and-set-screen-supports-HDR-sett
 SRC_URI += "file://2.38.8/1463_GStreamer-support-the-eotf-additional-MIME-type.patch"
 SRC_URI += "file://2.38.8/1467.patch"
 SRC_URI += "file://2.38.8/1608_MemoryPressureMonitor.patch"
+SRC_URI += "file://2.38.8/1605_Enable-new-dtags_flags-in-wpe-webkit.patch"
+SRC_URI += "file://2.38.8/1611_Load-libWPEWebInspectorResources-from-widget.patch"
 
 # Drop after libwpe upgrade
 SRC_URI += "file://2.38.8/RDK-54304-Fix-build-with-an-older-libpwe.patch"

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
@@ -7,14 +7,14 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r28"
+PR  = "r29"
 
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
 DEPENDS:append = " libtasn1 unifdef-native libsoup libepoxy libgcrypt fontconfig"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-# Tip of the branch on Feb 05, 2026
-SRCREV = "0e580742ac31c67cf2dd9298fafb64e2b7879683"
+# Tip of the branch on Feb 12, 2026
+SRCREV = "f51e896b362fe7b1f99c681afb72e3798c76fee6"
 
 BASE_URI ?= "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=http;branch=wpe-2.46"
 SRC_URI = "${BASE_URI}"


### PR DESCRIPTION
RDKEMW-3838: Pass RUNPATH $ORIGIN:$ORIGIN../../lib to webkit if defied distro wpe_webkit_enable_new_dtags_runpath .

Change-Id: Ifa4d70c4480fc27ed6fa893a8cbad0b589c9bc16