### PR TITLE
RDKEVD-5910:HALIF header 4.1.2.

### DIFF
--- a/recipes-extended/devicesettings/devicesettings_git.bb
+++ b/recipes-extended/devicesettings/devicesettings_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 PV = "1.0.29"
 PR = "r0"
 
-SRCREV_devicesettings = "edc8c70b9a8853e99ae364eb50ea85de131ac109"
+SRCREV_devicesettings = "c23ca3407f5a6ce46b5d5514945515f1a5ebf128"
 SRC_URI = "${CMF_GITHUB_ROOT}/devicesettings;${CMF_GITHUB_SRC_URI_SUFFIX};name=devicesettings"
 
 # devicesettings is not a 'generic' component, as some of its source


### PR DESCRIPTION
Reason for change:Inclusion of HALIF latest version. 
Test Procedure:Build and verify.