### PR TITLE
RDKEMW-14181: Firebolt: Enable legacy protocol (#2906)

### DIFF
--- a/recipes-extended/firebolt-cpp-client/firebolt-cpp-client.bb
+++ b/recipes-extended/firebolt-cpp-client/firebolt-cpp-client.bb
@@ -8,11 +8,11 @@ inherit cmake
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-PV = "0.3.0"
+PV = "0.4.0"
 PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-client/releases/download/v${PV}/firebolt-cpp-client-${PV}.tar.gz"
-SRC_URI[sha256sum] = "64eeeb6dd30ad6c12934946b3b55340675075c4a604df25de1d29ecfa07b8ddd"
+SRC_URI[sha256sum] = "882ae584465afc6205e54869668795ab2ff290d41ac843ca11613da45776662c"
 
 S = "${WORKDIR}/firebolt-cpp-client-${PV}"
 

--- a/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
+++ b/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
@@ -8,16 +8,21 @@ inherit cmake
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-PV = "1.0.0"
+PV = "1.1.0"
 PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-transport/releases/download/v${PV}/firebolt-cpp-transport-${PV}.tar.gz"
-SRC_URI[sha256sum] = "2ff666c266ec22f9ed7989b1c4d3a7c6c2df24a8880d8587179236ccfac24163"
+SRC_URI[sha256sum] = "be82779706783041f1f343b97d94d45b806702a0b8e471b3df93eb0750df6084"
 
 S = "${WORKDIR}/firebolt-cpp-transport-${PV}"
 
 DEPENDS = "nlohmann-json websocketpp boost"
 RDEPENDS:${PN} = "websocketpp boost-system"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[legacy-rpc-v1] = "-DENABLE_LEGACY_RPC_V1=ON,-DENABLE_LEGACY_RPC_V1=OFF"
+
+EXTRA_OECMAKE:append = " ${PACKAGECONFIG_CONFARGS}"
 
 PACKAGES = "${PN} ${PN}-dev ${PN}-dbg"
 

--- a/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bbappend
+++ b/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " legacy-rpc-v1"


### PR DESCRIPTION
Reason for change: Until AppGateway and 8.5 fully deployed, firebolt clients should have reliable communication with current versions of AppGateway/Ripple.

Test Procedure: Build the image

Risks: Low

Change-Id: Iaacaf45681e6c65954aa41d2b5efeaf806955d52