### PR TITLE
RDKEMW-13124, RDKEMW-14287, RDKEMW-13683: NetworkManager release 1.12.3

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,12 +14,12 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "1.9.0"
+PV = "1.12.3"
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=main"
+SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=support/1.12.0"
 
-SRCREV = "8c6ec3e7844751af886a19a1c2a8152d221ddb0c"
+SRCREV = "d4244e0822c33c1566af7d089793eda4370057d3"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry iarmbus iarmmgrs ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', '', d)} "


### PR DESCRIPTION
Reason for change: NetworkManager release 1.12.3 with following fixes 
-Implemented logic to always enable WiFi upon migration
-Fixed the Activate Connection method to connect given (Ethernet and WiFi) connectionID
-The onAvailableSSIDs event signature changed to report strength, noise & frequency as Number 
Test Procedure: NA
Priority:P1
Risks: Medium