### PR TITLE
RDK-60535: wpe-webkit 2.46 rev upgrade

### DIFF
--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
@@ -7,14 +7,14 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r30"
+PR  = "r31"
 
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
 DEPENDS:append = " libtasn1 unifdef-native libsoup libepoxy libgcrypt fontconfig"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-# Tip of the branch on Feb 12, 2026
-SRCREV = "f51e896b362fe7b1f99c681afb72e3798c76fee6"
+# Tip of the branch on Feb 25, 2026
+SRCREV = "e2f95c3a5cf6bd31938302b431941be0357b89ac"
 
 BASE_URI ?= "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=http;branch=wpe-2.46"
 SRC_URI = "${BASE_URI}"


### PR DESCRIPTION
1) New Page Lifecycle API
2) Reduce GPU mem usage / spikes
3) [MSE] Fix sample DTS to prevent deletion of preexisting samples when PTS doesn't conflict

Reason for change: WebKit revision upgrade
Test Procedure: WebApps smoke testing
Priority: P1
Risks: Low