### PR TITLE
RDK-60924 : Addition SRCREV of RFC parameter for Stage

### DIFF
--- a/recipes-thirdparty/tr69hostif/tr69hostif-headers_git.bb
+++ b/recipes-thirdparty/tr69hostif/tr69hostif-headers_git.bb
@@ -8,7 +8,7 @@ PV = "1.3.3"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-SRCREV = "4a3ef83dbb2fe8f39e4a6edd0c6a28461d83d235"
+SRCREV = "5357e52ff99c594ee21ffb28707b7cd255ed950e"
 SRC_URI = "${CMF_GITHUB_ROOT}/tr69hostif;${CMF_GITHUB_SRC_URI_SUFFIX};name=tr69hostif"
 
 DEPENDS += "safec-common-wrapper"

--- a/recipes-thirdparty/tr69hostif/tr69hostif_git.bb
+++ b/recipes-thirdparty/tr69hostif/tr69hostif_git.bb
@@ -4,7 +4,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=99e7c83e5e6f31c2cbb811e186972945"
 
-SRCREV = "4a3ef83dbb2fe8f39e4a6edd0c6a28461d83d235"
+SRCREV = "5357e52ff99c594ee21ffb28707b7cd255ed950e"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/tr69hostif;${CMF_GITHUB_SRC_URI_SUFFIX};name=tr69hostif"
 PV = "1.3.3"


### PR DESCRIPTION
US: RDK-60377: Subtask: RDK-60924 - Addition of RFC parameter for Stage Agent

Reason for change: Add RFC flag Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.STAGE.Enable
to execute the app
Test Procedure: Build with stage agent changes and test
Risks: None

Is this a Bug or a User Story (US)?: US: RDK-60377 - STAGE development - Phase 1 (SSH trigger). Subtask: RDK-60924
2. If it is a User Story:

Have all dependent PRs from other components been listed (if any)?: Below PR's are dependent PR's: No.
Does the commit message include both the User Story ticket and the Subtask ticket?
Yes
Will be all changes related to the User Story squashed and merged in a single commit?: No
Has the PR been raised only after completing all changes for the User Story (no partial changes)? : Yes
Has code development for the User Story been completed?: Yes
If yes, has the Gerrit topic or list of all dependent PRs across components (including meta-layer changes) been shared?:https://gerrit.teamccp.com/#/c/945985/
Is there a validation log available in the Jira ticket for verifying builds with the updated generic-srcrev.inc across all platforms?: Yes
If yes, have the links to validation comments been shared?: https://ccp.sys.comcast.net/secure/attachment/14230070/14230070_D89C8E72F2E0_Stage_Logs_02-20-26-06-19AM.tgz