### PR TITLE
RDKEMW-15096: Missing slash in URL causes query argument to be ignore…

### DIFF
--- a/recipes-extended/firebolt-cpp-client/firebolt-cpp-client.bb
+++ b/recipes-extended/firebolt-cpp-client/firebolt-cpp-client.bb
@@ -8,11 +8,11 @@ inherit cmake
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-PV = "0.5.1"
+PV = "0.5.2"
 PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-client/releases/download/v${PV}/firebolt-cpp-client-${PV}.tar.gz"
-SRC_URI[sha256sum] = "b3c59801ec5a4d9233e4f2a398d42ea9e39adad7377ec265dda690c50489f625"
+SRC_URI[sha256sum] = "9ffe497fa52b9a1d6c0b271ed5d4bbde52e6ef02efd4917d91fbb1665848dee4"
 
 S = "${WORKDIR}/firebolt-cpp-client-${PV}"
 

--- a/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
+++ b/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
@@ -8,11 +8,11 @@ inherit cmake
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-PV = "1.1.3"
+PV = "1.1.4"
 PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-transport/releases/download/v${PV}/firebolt-cpp-transport-${PV}.tar.gz"
-SRC_URI[sha256sum] = "0a0c9394395a514d3ba6931a6c656886523c6b3f038b0cb991c27c837f0e506e"
+SRC_URI[sha256sum] = "218e1b2ee41404fe1ccda3bb0cea885c9c6d1cc0ac89f94c929129fcb388d5ea"
 
 S = "${WORKDIR}/firebolt-cpp-transport-${PV}"
 


### PR DESCRIPTION
…d (#3099)

Reason for change: If the URL passed in the configuration did not end with a '/', the remaining query arguments were truncated by websocketpp and not passed to the endpoint.

Test Procedure: Build the image
Risks: low
Priority: P2

Change-Id: I8694fa3ac0a941ded2905c01bd13f68ad8a700b2