### PR TITLE
RDK-55906: [socprov.log] Data Collection Through T2 Events For socprov.log

### DIFF
--- a/recipes-extended/entservices/entservices-powermanager.bb
+++ b/recipes-extended/entservices/entservices-powermanager.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices powermanager plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=be650d9617f9f9d24bcaccf78a97b28b"
 
-PV = "1.0.3"
+PV = "1.1.1"
 PR = "r0"
 
 S = "${WORKDIR}/git"
@@ -13,8 +13,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-powermanager;${CMF_GITHUB_SRC_URI_SUFF
            file://rdkservices.ini \
           "
 
-# Release version - 1.0.3
-SRCREV = "0908ece6a1fb3b0ef5b5ae843abdcb7eb49915b7"
+# Release version - 1.1.1
+SRCREV = "b3e90917ce42584eab7f50c937385e0d293f564a"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/entservices/entservices-runtime.bb
+++ b/recipes-extended/entservices/entservices-runtime.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices runtime plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dc6e390ad71aef79d0c2caf3cde03a19"
 
-PV = "1.2.0"
+PV = "1.2.3"
 PR = "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-runtime;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.2.0
-SRCREV = "5ab664b1c9875c2a2ad329ebcf9e966832d61c28"
+# Release version - 1.2.3
+SRCREV = "851bb16d4f4c6890c5a6a879b8586b62c265f09e"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-telemetry.bb
+++ b/recipes-extended/entservices/entservices-telemetry.bb
@@ -2,13 +2,13 @@ SUMMARY = "ENTServices telemetry plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2a944942e1496af1886903d274dedb13"
 
-PV = "1.0.2"
+PV = "1.0.4"
 PR = "r0"
 
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
-SRCREV = "6f5738dbfc3e0d2d59143dcdb03edbc21ca0acd6"
+SRCREV = "8b82fc93089910596c0b94407eed868bcdaed4b5"
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-telemetry;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://rdkservices.ini \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \


### PR DESCRIPTION
Reason for change: Adding t2 events for DeviceProvisioning plugin
Test Procedure: see Jira ticket
Risks: Low
Priority: Medium