### PR TITLE
RDKEVD-5021 : blocklist changes (#2508)

### DIFF
--- a/recipes-extended/iarmmgrs/iarmmgrs_git.bb
+++ b/recipes-extended/iarmmgrs/iarmmgrs_git.bb
@@ -5,13 +5,13 @@ LICENSE = "Apache-2.0 & ISC"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=83a31d934b0cc2ab2d44a329445b4366"
 
 
-PV = "1.1.9"
+PV = "1.1.10"
 PR = "r0"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SAVEDDIR := "${THISDIR}"
 
-SRCREV = "0223e8afc6d4fcda29e6300313d1dc0b5ba5279d"
+SRCREV = "422bc8cd41d6ac3c49a7b828159cf09874b467e5"
 SRC_URI = "${CMF_GITHUB_ROOT}/iarmmgrs;${CMF_GITHUB_SRC_URI_SUFFIX};name=iarmmgrs"
 SRCREV_FORMAT = "iarmmgrs"
 #SRC_URI:append = " file://irmgr.diff"
@@ -272,7 +272,6 @@ do_install:append(){
         install -m 0755 ${S}/mfr/test_mfr/mfr_wifiEraseAllData ${D}${bindir}
         install -m 0755 ${S}/mfr/test_mfr/mfr_wifiSetCredentials ${D}${bindir}
         install -m 0755 ${S}/mfr/test_mfr/mfr_wifiGetCredentials ${D}${bindir}
-
 }
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'ctrlm', 'ctrlm-headers', '', d)}"


### PR DESCRIPTION
* RDKEVD-5021 : [RDK-E] Vendor layer support for store and read blocklist flag values in bootloader flash securely
Reason for change: updating with merge commit of iarmmgr



* RDKEVD-5021 : [RDK-E] Vendor layer support for store and read blocklist flag values in bootloader fl
Reason for change: updating with 1.1.10 release tag commit



---------