### PR TITLE
RDKEMW-15258: [support/8.4.4.0]WPEFramework crash observed with RemoteConnectionMap::Closed during runtime

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/PR-1832-ABBA-Deadlock-Fix-RDKTV-35315.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/PR-1832-ABBA-Deadlock-Fix-RDKTV-35315.patch
@@ -1,29 +1,21 @@
-From: Metro Team
-Date: Fri, 07 Feb 2024 11:07:28 +0000
-Subject: [PATCH] 001-PR1832-RDKTV-35315.patch
-
-Upstream-Status: Backport from Thunder R4_4 branch
-Signed-off-by: Thamim Razith <tabbas651@cable.comcast.com>
-Signed-off-by: Boopathi Vanavarayan <boopathi_vanavarayan@comcast.com>
----
 diff --git a/Source/com/Communicator.h b/Source/com/Communicator.h
-index b8716586c..a8db49e59 100644
+index d691d8a3c..152d1b006 100644
 --- a/Source/com/Communicator.h
 +++ b/Source/com/Communicator.h
-@@ -1059,14 +1059,14 @@ namespace RPC {
+@@ -1062,14 +1062,13 @@ namespace RPC {
                          observer++;
                      }
  
 -                    // Don't forget to close on our side as well, if it is not already closed....
 -                    index->second->Terminate();
- 
+-
                      // Release this entry, do not wait till it get's overwritten.
                      index->second->Release();
                      _connections.erase(index);
                      _adminLock.Unlock();
  
 +                    // Don't forget to close on our side as well, if it is not already closed....
-+                    index->second->Terminate();
++                    connection->Terminate();
                      connection->Release();
                  }
              }

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -57,7 +57,7 @@ SRC_URI += "file://r4.4/PR-1369-Wait-for-Open-in-Communication-Channel.patch \
             file://r4.4/PR-1785-Reduce_scope_of_adminlock.patch \
             file://r4.4/PR-1791-Thunder-hung-SocketPort-close-Delete-channel.patch \
             file://r4.4/PR-1797-SocketPort-Closed.patch \
-            file://r4.4/PR1832-Thunder-ABBA-Deadlock-Fix.patch \
+            file://r4.4/PR-1832-ABBA-Deadlock-Fix-RDKTV-35315.patch \
             file://r4.4/0001-DELIA-65784-Hibernation-fixes-for-R4.4.patch \
             file://r4.4/0001-SmarkLink-Crash-Fix.patch \
             file://r4.4/Jsonrpc_dynamic_error_handling.patch \


### PR DESCRIPTION
Reason for change: Updating the patch to align with the original fix Test Procedure: reboot
Risks: Low
Priority: P1
Signed-off-by:Boopathi Vanavarayan <boopathi_vanavarayan@comcast.com>