### PR TITLE
RDKEMW-11195:Some systemd files are not included in builds

### DIFF
--- a/recipes-extended/thunderstartupservices/thunderstartupservices.bb
+++ b/recipes-extended/thunderstartupservices/thunderstartupservices.bb
@@ -16,14 +16,6 @@ SRC_URI = "git://github.com/rdkcentral/thunder-startup-services.git;protocol=git
 "
 S = "${WORKDIR}/git/systemd/system"
 
-THUNDER_STARTUP_SERVICES:rdktv-uk-armv7a = " \
-    wpeframework-motiondetection.service \
-    "
-
-THUNDER_STARTUP_SERVICES:sky-llama-it= " \
-    wpeframework-motiondetection.service \
-    "
-
 THUNDER_STARTUP_SERVICES:append = "\
     wpeframework-avinput.service \
     wpeframework-bluetooth.service \


### PR DESCRIPTION
Reason for change: Installing motiondetection service only in llama devices
Test Procedure: verify motiondetection service is active on bootup in llama deveices
Risks: Low
version : minor
Priority: P1
 
Signed-off-by:AkshayKumar_Gampa [AkshayKumar_Gampa@comcast.com](mailto:AkshayKumar_Gampa@comcast.com)