### PR TITLE
RDKEMW-15423: Fix for cobalt crash during Maintenance reboot

### DIFF
--- a/recipes-extended/cobalt/files/25/0007-Prevent-cobalt-unloading.patch
+++ b/recipes-extended/cobalt/files/25/0007-Prevent-cobalt-unloading.patch
@@ -1,0 +1,28 @@
+From 4c184d0a5d9ad9f1397259903db07dac4ef3399c Mon Sep 17 00:00:00 2001
+From: shahin217 <shahinn217@gmail.com>
+Date: Mon, 12 May 2025 16:58:36 +0530
+Subject: [PATCH] Prevent cobalt unload
+
+---
+ starboard/elf_loader/program_table.cc | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/starboard/elf_loader/program_table.cc b/starboard/elf_loader/program_table.cc
+index 3dcb3e26a7d..4268f6819f3 100644
+--- a/starboard/elf_loader/program_table.cc
++++ b/starboard/elf_loader/program_table.cc
+@@ -408,6 +408,11 @@ Addr ProgramTable::GetBaseMemoryAddress() {
+ 
+ ProgramTable::~ProgramTable() {
+   SetEvergreenInfo(NULL);
++
++  SB_LOG(INFO) << "Skip UnLoad start=" << std::hex << load_start_
++               << " base_memory_address=0x" << base_memory_address_;
++  return;
++
+   if (load_start_) {
+     munmap(load_start_, load_size_);
+   }
+-- 
+2.34.1
+

--- a/recipes-extended/cobalt/libloader-app_25.lts.stable.bb
+++ b/recipes-extended/cobalt/libloader-app_25.lts.stable.bb
@@ -25,6 +25,7 @@ SRC_URI += "file://25/0003-breakpad-add-mapping-info.patch"
 SRC_URI += "file://25/0004-Build-fix-for-ARM64.patch"
 SRC_URI += "file://25/0005-Use-Yocto-host-toolchain.patch"
 SRC_URI += "file://25/0006-Use-certifi-to-tell-urllib-where-to-find-CA-file-397.patch"
+SRC_URI += "file://25/0007-Prevent-cobalt-unloading.patch"
 
 CR = "30"
 PR = "r${CR}"


### PR DESCRIPTION
Reason for change: Fix for cobalt crash during Maintenance reboot by Importing Prevent unloading Patch to cobalt-25
Test Procedure: Verify via test.
Risks: None identified.