### PR TITLE
RDKEMW-15105: Networkmanager plugin release v1.12.4

### DIFF
--- a/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
+++ b/recipes-extended/networkmgr-plugin/networkmanager-plugin_git.bb
@@ -14,13 +14,13 @@ NETWORKMANAGER_STUN_PORT ?= "19302"
 NETWORKMANAGER_LOGLEVEL ?= "3"
 
 PR = "r0"
-PV = "1.12.3"
+PV = "1.12.4"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/rdkcentral/networkmanager.git;protocol=https;branch=support/1.12.0"
 
-# Feb 19, 2026
-SRCREV = "d4244e0822c33c1566af7d089793eda4370057d3"
+# Mar 13, 2026
+SRCREV = "6500f5f0fb6d3a68e8eb37c160b29189105e7fb0"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DEPENDS = " openssl rdk-logger zlib boost curl glib-2.0 wpeframework entservices-apis wpeframework-tools-native libsoup-2.4 gupnp gssdp telemetry iarmbus iarmmgrs ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', ' networkmanager ', '', d)} "


### PR DESCRIPTION
Reason for Change: Release of networkmanager v1.12.4 with the fix for ethernet connection issue during migration scenario
Test Procedure: Migration Scenario
Priority: P0
Risks: Medium