### PR TITLE
RDKEMW-15532: Firebolt: Disable so-version in the library

### DIFF
--- a/recipes-extended/firebolt-cpp-client/firebolt-cpp-client.bb
+++ b/recipes-extended/firebolt-cpp-client/firebolt-cpp-client.bb
@@ -8,16 +8,21 @@ inherit cmake
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-PV = "0.5.3"
+PV = "0.5.5"
 PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-client/releases/download/v${PV}/firebolt-cpp-client-${PV}.tar.gz"
-SRC_URI[sha256sum] = "1c7d304fc594acde1549d49e9f8935a8ed7fcaaf7c01667180d1f3b787925c22"
+SRC_URI[sha256sum] = "9ecb43d70cfe9f5737d28c2cae150e8b3258a70a54cb77982fa7da508aecfbbd"
 
 S = "${WORKDIR}/firebolt-cpp-client-${PV}"
 
 DEPENDS = "firebolt-cpp-transport nlohmann-json"
 RDEPENDS:${PN} = "firebolt-cpp-transport"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[disable-so-version] = "-DDISABLE_SO_VERSION=ON,-DDISABLE_SO_VERSION=OFF"
+
+EXTRA_OECMAKE:append = " ${PACKAGECONFIG_CONFARGS}"
 
 PACKAGES = "${PN} ${PN}-dev ${PN}-dbg"
 

--- a/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
+++ b/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
@@ -8,19 +8,20 @@ inherit cmake
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-PV = "1.1.5"
+PV = "1.1.6"
 PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-transport/releases/download/v${PV}/firebolt-cpp-transport-${PV}.tar.gz"
-SRC_URI[sha256sum] = "ecf662735ba6619022158ffac2717ec1c5c4c4055705db5d7b475d3c461d5e90"
+SRC_URI[sha256sum] = "fba0193b4fbc69b68b3c9674d102ef3d95aca923af020d6b35d75713aaf35369"
 
 S = "${WORKDIR}/firebolt-cpp-transport-${PV}"
 
 DEPENDS = "nlohmann-json websocketpp boost"
-RDEPENDS:${PN} = "websocketpp boost-system"
+RDEPENDS:${PN} = "boost-system"
 
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[legacy-rpc-v1] = "-DENABLE_LEGACY_RPC_V1=ON,-DENABLE_LEGACY_RPC_V1=OFF"
+PACKAGECONFIG[disable-so-version] = "-DDISABLE_SO_VERSION=ON,-DDISABLE_SO_VERSION=OFF"
 
 EXTRA_OECMAKE:append = " ${PACKAGECONFIG_CONFARGS}"
 


### PR DESCRIPTION
RDKEMW-15532 : Firebolt: Disable so-version in the library

Reason for change: Allow to link widget with Prime App to Firebolt libraries without version control

Test Procedure: Build the image
Risks: low
Priority: P2