### PR TITLE
RDKEMW-14984: VIPA playback is stopping with 2.0.3 nativescript tag

### DIFF
--- a/recipes-graphics/rdknativescript/rdknativescript_git.bb
+++ b/recipes-graphics/rdknativescript/rdknativescript_git.bb
@@ -13,13 +13,13 @@ inherit cmake pkgconfig perlnative ${@bb.utils.contains("DISTRO_FEATURES", "kirk
 
 S = "${WORKDIR}/git"
 
-PV = "2.0.3"
+PV = "2.0.4"
 PR = "r0"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/rdkNativeScript;${CMF_GITHUB_SRC_URI_SUFFIX};"
 
-#Release 2.0.3
-SRCREV = "8ae59eff3b967bc773d5bff2f8b68b9d9a94dbc9"
+#Release 2.0.4
+SRCREV = "47ecb4b1aab79825037823dc30eeb0221787c265"
 
 OECMAKE_GENERATOR = "Ninja"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
Reason for change: Update tag to 2.0.4 rdknativescript changed the jsbinding lib for dynamic loading
Test Procedure: build should be successful
Risk: low
Priority: P2