### PR TITLE
RDKEMW-15653 - t2_init changes for telemetry

### DIFF
--- a/recipes-extended/entservices/entservices-powermanager.bb
+++ b/recipes-extended/entservices/entservices-powermanager.bb
@@ -13,8 +13,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-powermanager;${CMF_GITHUB_SRC_URI_SUFF
            file://rdkservices.ini \
           "
 
-# Release version - 1.0.4
-SRCREV = "556400e37137b7dc06716159e22c74405dcb7741"
+# Release version - 1.1.4
+SRCREV = "dbe8ea5f40245c529161257f36c806d2da4d68e5"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/hdmicec/hdmicec_git.bb
+++ b/recipes-extended/hdmicec/hdmicec_git.bb
@@ -4,11 +4,11 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-PV = "1.0.9"
+PV = "1.0.10"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-SRCREV_hdmicec = "f4ed04882f2930a8da8fe912463d550581b5979c"
+SRCREV_hdmicec = "1ce51f4b0592f75775797e600998419054be6ade"
 SRC_URI = "${CMF_GITHUB_ROOT}/hdmicec;${CMF_GITHUB_SRC_URI_SUFFIX};name=hdmicec"
 SRCREV_FORMAT = "hdmicec"
 


### PR DESCRIPTION
Reason for change: Proper t2_init
Test Procedure: Test telemetry markers
Risks: Low
Priority: P1
version: ignore