### PR TITLE
RDKEMW-16060 : [8.4.4.0][WTA] RDK API getDeviceInfo Returns Bluetooth MAC with Trailing Escape Sequence

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices deviceanddisplay plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dc6e390ad71aef79d0c2caf3cde03a19"
 
-PV ?= "3.4.4.5"
+PV ?= "3.4.4.7"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 3.4.4.5
-SRCREV = "f5b78fd2f17895e8997184c9d46f55cff1c88f5e"
+# Release version - 3.4.4.7
+SRCREV = "42b32dded06de811967a0087c8496d701b032579"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
           "
 
 # Release version - 3.4.4.5
-SRCREV = "f6e5fccf2f29e3a211e83f118782fc41ef0ed24d"
+SRCREV = "f5b78fd2f17895e8997184c9d46f55cff1c88f5e"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: bluetooth_mac appends esc sequence in the end.
Test Procedure: check the bluetooth_mac via"org.rdk.System.getDeviceInfo". there should be no esc sequence in the end of bluetooth_mac
Risks: Low
version : minor
Priority: P1

Signed-off-by:Naveen_Dunna [Naveen_Dunna@comcast.com](mailto:Naveen_Dunna@comcast.com)