### PR TITLE
RDKEMW-16000: Add refreshHandles in libds.

### DIFF
--- a/recipes-extended/devicesettings/devicesettings_git.bb
+++ b/recipes-extended/devicesettings/devicesettings_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 PV = "1.0.31"
 PR = "r1"
 
-SRCREV_devicesettings = "279e97ce41ee172d89938c770d4d41f674fef1ff"
+SRCREV_devicesettings = "d1b0449e6c50ffeb898c625caf10b32faa6f38d0"
 SRC_URI = "${CMF_GITHUB_ROOT}/devicesettings;${CMF_GITHUB_SRC_URI_SUFFIX};name=devicesettings"
 
 # devicesettings is not a 'generic' component, as some of its source

--- a/recipes-extended/devicesettings/devicesettings_git.bb
+++ b/recipes-extended/devicesettings/devicesettings_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 PV = "1.0.31"
 PR = "r1"
 
-SRCREV_devicesettings = "d1b0449e6c50ffeb898c625caf10b32faa6f38d0"
+SRCREV_devicesettings = "55d4d3a274ec20c063dec3b0e31945610690d02f"
 SRC_URI = "${CMF_GITHUB_ROOT}/devicesettings;${CMF_GITHUB_SRC_URI_SUFFIX};name=devicesettings"
 
 # devicesettings is not a 'generic' component, as some of its source

--- a/recipes-extended/devicesettings/devicesettings_git.bb
+++ b/recipes-extended/devicesettings/devicesettings_git.bb
@@ -5,9 +5,9 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PV = "1.0.31"
-PR = "r0"
+PR = "r1"
 
-SRCREV_devicesettings = "08ade67217d2157cfe0f48154773ac168cba189b"
+SRCREV_devicesettings = "279e97ce41ee172d89938c770d4d41f674fef1ff"
 SRC_URI = "${CMF_GITHUB_ROOT}/devicesettings;${CMF_GITHUB_SRC_URI_SUFFIX};name=devicesettings"
 
 # devicesettings is not a 'generic' component, as some of its source

--- a/recipes-extended/devicesettings/devicesettings_git.bb
+++ b/recipes-extended/devicesettings/devicesettings_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 PV = "1.0.31"
 PR = "r1"
 
-SRCREV_devicesettings = "55d4d3a274ec20c063dec3b0e31945610690d02f"
+SRCREV_devicesettings = "a8007ad071e037229c2c5445fab36a9bb0e137ea"
 SRC_URI = "${CMF_GITHUB_ROOT}/devicesettings;${CMF_GITHUB_SRC_URI_SUFFIX};name=devicesettings"
 
 # devicesettings is not a 'generic' component, as some of its source

--- a/recipes-extended/devicesettings/devicesettings_git.bb
+++ b/recipes-extended/devicesettings/devicesettings_git.bb
@@ -5,9 +5,9 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PV = "1.0.31"
-PR = "r1"
+PR = "r2"
 
-SRCREV_devicesettings = "a8007ad071e037229c2c5445fab36a9bb0e137ea"
+SRCREV_devicesettings = "8d83e90f9452e36f81cf26cfefe1d50099c15cd8"
 SRC_URI = "${CMF_GITHUB_ROOT}/devicesettings;${CMF_GITHUB_SRC_URI_SUFFIX};name=devicesettings"
 
 # devicesettings is not a 'generic' component, as some of its source

--- a/recipes-extended/iarmmgrs/iarmmgrs_git.bb
+++ b/recipes-extended/iarmmgrs/iarmmgrs_git.bb
@@ -6,12 +6,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=83a31d934b0cc2ab2d44a329445b4366"
 
 
 PV = "1.1.13"
-PR = "r1"
+PR = "r2"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SAVEDDIR := "${THISDIR}"
 
-SRCREV = "1ce2d3c26a7825ec693a810361a5672b964eb871"
+SRCREV = "010ed21cd588647f25d2759bc5d63b51a0773c47"
 SRC_URI = "${CMF_GITHUB_ROOT}/iarmmgrs;${CMF_GITHUB_SRC_URI_SUFFIX};name=iarmmgrs"
 SRCREV_FORMAT = "iarmmgrs"
 #SRC_URI:append = " file://irmgr.diff"

--- a/recipes-extended/iarmmgrs/iarmmgrs_git.bb
+++ b/recipes-extended/iarmmgrs/iarmmgrs_git.bb
@@ -6,12 +6,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=83a31d934b0cc2ab2d44a329445b4366"
 
 
 PV = "1.1.13"
-PR = "r0"
+PR = "r1"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SAVEDDIR := "${THISDIR}"
 
-SRCREV = "b6b5e6aeb82cfba5663c67eb9a5c7d3d63c275e3"
+SRCREV = "1ce2d3c26a7825ec693a810361a5672b964eb871"
 SRC_URI = "${CMF_GITHUB_ROOT}/iarmmgrs;${CMF_GITHUB_SRC_URI_SUFFIX};name=iarmmgrs"
 SRCREV_FORMAT = "iarmmgrs"
 #SRC_URI:append = " file://irmgr.diff"


### PR DESCRIPTION
Reason for change: Refresh libds stale handle when dsmgr restart.
Test Procedure: refer RDKEMW-16000
Risks: High
Signed-off-by:gsanto722 <grandhi_santoshkumar@comcast.com>