### PR TITLE
RDKEMW-16503: Fix for AVInput Thunder plugins request/response logs not coming in WPEFramework log

### DIFF
--- a/recipes-extended/entservices/entservices-avinput.bb
+++ b/recipes-extended/entservices/entservices-avinput.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices avinput plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-PV = "1.0.4"
+PV = "1.2.0"
 PR = "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-avinput;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 1.0.4
-SRCREV = "d30be26a5c586acb0c8cc438f7e3a6c7c7dba2d2"
+# Release version - 1.2.0
+SRCREV = "1ab78f1d9fd68393bd3915451afa18f7fa755682"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: Fix for AVInput Thunder plugins request/response logs not coming in WPEFramework log
Test Procedure : compiled and verified
Version : Minor
Risks: Low