### PR TITLE
RDKEMW-16729: increase in TTS failures

### DIFF
--- a/recipes-extended/rdkat/rdkat.bb
+++ b/recipes-extended/rdkat/rdkat.bb
@@ -6,10 +6,10 @@ detects the DOM events and provides the ARIA information to TTS"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-PV = "1.1.0"
+PV = "1.1.1"
 PR = "r0"
 
-SRCREV = "1721ae4921dc94d28e36c027c81cb5695b205832"
+SRCREV = "a5fd9df4078194df81236b8b1f7c5b79cb3cdc03"
 SRC_URI = "${CMF_GITHUB_ROOT}/rdkat;${CMF_GITHUB_SRC_URI_SUFFIX}"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
Reason for change: removing tts for system apps
Test Procedure: Mentioned in ticket
Risks: Low
version: minor