### PR TITLE
RDKEMW-16629: fbcpp transport 1.1.8  to develop

### DIFF
--- a/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
+++ b/recipes-extended/firebolt-cpp-transport/firebolt-cpp-transport.bb
@@ -8,12 +8,12 @@ inherit cmake
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-PV = "1.1.6"
+PV = "1.1.8"
 PR = "r0"
 
 SRC_URI = "https://github.com/rdkcentral/firebolt-cpp-transport/releases/download/v${PV}/firebolt-cpp-transport-${PV}.tar.gz"
-SRC_URI[sha256sum] = "fba0193b4fbc69b68b3c9674d102ef3d95aca923af020d6b35d75713aaf35369"
-
+SRC_URI[sha256sum] = "0af04e3040cc87f92f05d0c35662792d95403b801e221aeb2e263af72a4c4966"
+                      
 S = "${WORKDIR}/firebolt-cpp-transport-${PV}"
 
 DEPENDS = "nlohmann-json websocketpp boost"


### PR DESCRIPTION
- Update develop of meta layer to latest firebolt c++ transport layer to add additional logging and incremental progress towards fixing timeout issues.