### PR TITLE
RDKEMW-15693: Add API to clear CDN access token for AuthService plugin

### DIFF
--- a/recipes-extended/wpe-framework/entservices-apis/RDKEMW-1007.patch
+++ b/recipes-extended/wpe-framework/entservices-apis/RDKEMW-1007.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000..aabed49
 --- /dev/null
 +++ b/apis/AuthService/IAuthService.h
-@@ -0,0 +1,485 @@
+@@ -0,0 +1,492 @@
 +/*
 + * If not stated otherwise in this file or this component's LICENSE file the
 + * following copyright and licenses apply:
@@ -223,7 +223,7 @@ index 0000000..aabed49
 +    // @brief Retrieves the content access token from the secure persistent location
 +    // @param token - out - string
 +    // @param expires - out - uint32_t
-+    // @return uint32_t - status/error code indicating success or failure of the operation
++    // @return Core::hresult - status/error code indicating success or failure of the operation
 +    virtual Core::hresult GetContentAccessToken(string& token /* @out */, uint32_t& expires /* @out */) = 0;
 +    /**********************getContentAccessToken() - end****************************/
 +
@@ -406,7 +406,14 @@ index 0000000..aabed49
 +    // @brief Clears the authorization token
 +    // @param SuccessMsgResult - out - struct
 +    virtual uint32_t ClearAuthToken(SuccessMsgResult& setStat /* @out */) = 0;
-+    /**********************clearAuthToken() - start****************************/
++    /**********************clearAuthToken() - end****************************/
++
++    /**********************clearContentAccessToken() - start****************************/
++    // @text clearContentAccessToken
++    // @brief Clears the content access token from the secure persistent location
++    // @param SuccessMsgResult - out - struct
++    virtual Core::hresult ClearContentAccessToken(SuccessMsgResult& setStat /* @out */) = 0;
++    /**********************clearContentAccessToken() - end****************************/
 +
 +    /**********************clearSessionToken() - start****************************/
 +    // @text clearSessionToken


### PR DESCRIPTION
Reason for change: add api that clears the CDN token from secure persistent location
Test Procedure: see Jira ticket
Risks: None
Priority: P1