### PR TITLE
RDKEMW-10284: Migrate stunnel to use P12 cert

### DIFF
--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -8,7 +8,7 @@ PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 PV = "4.5.5"
 PR = "r0"
 
-SRCREV = "654be5fcc3473060f765481e5cd9dd4f84f65d95"
+SRCREV = "5eb986fd3b3fd7db27e89fd1bbe21f8011977667"
 SRC_URI = "${CMF_GITHUB_ROOT}/sysint;${CMF_GITHUB_SRC_URI_SUFFIX};module=.;name=sysint"
 S = "${WORKDIR}/git"
 

--- a/recipes-extended/sysint/sysint_git.bbappend
+++ b/recipes-extended/sysint/sysint_git.bbappend
@@ -56,12 +56,6 @@ do_install:append() {
                sed -i "s|response=|response=${NM_CONNECTIVITY_CHECK_RESPONSE}|g" ${D}${sysconfdir}/NetworkManager/conf.d/nm-connectivity.conf
            fi
     fi
-    if [ "${MACHINE}" = "es1-rtk-xumo" ]; then
-          if [ -f ${D}${base_libdir}/rdk/startStunnel.sh ]; then
-                bbnote "Disabling SHORTS"
-               sed -i 's/`tr181 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.SHORTS.Enable 2>&1 > \/dev\/null`/\"false\"/' ${D}${base_libdir}/rdk/startStunnel.sh
-          fi
-    fi
 }
 
 FILES:${PN} += "${sysconfdir}/udhcpc.vendor_specific"


### PR DESCRIPTION
RDKEMW-10284: Migrate stunnel to use P12 cert
Reason for change: To integrate SE based device cert for mTls connectivity in stunnel
Test Procedure: Build and verify SHORTS connectivity
Risks: None
Priority: P1