### PR TITLE
RDKEMW-17113: When Firebolt Display APIs are called logs are not get recorded in weframework.log

### DIFF
--- a/recipes-extended/entservices/entservices-displayinfo.bb
+++ b/recipes-extended/entservices/entservices-displayinfo.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices displayinfo plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-PV = "1.1.2"
+PV = "1.2.3"
 PR = "r0"
 
 S = "${WORKDIR}/git"
@@ -13,8 +13,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-displayinfo;${CMF_GITHUB_SRC_URI_SUFFI
            file://rdkservices.ini \
           "
 
-# Release version - 1.1.2
-SRCREV = "6d27bc2bdc7dfa80d026864dae3610ebd7e54b68"
+# Release version - 1.2.3
+SRCREV = "a3fc533e7dad6fb3544442a7c3342102a8d56186"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: When Firebolt Display APIs are called logs are not get recorded in weframework.log 
Test Procedure: Check the wpeframework logs
Risks: Low
Priority: P1
version: Patch
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]