### PR TITLE
VPLAY-13206: Ad rewind results in playing at 1x speed for 1-2s

### DIFF
--- a/recipes-extended/aamp/aamp_git.bb
+++ b/recipes-extended/aamp/aamp_git.bb
@@ -7,7 +7,7 @@ PV ?= "3.3.0"
 PR ?= "r0"
 
 SRCREV_FORMAT = "aamp"
-SRCREV_aamp ?= "32ffcb2f9ba33838d243954abca53a9195cc2762"
+SRCREV_aamp ?= "dd4344fd1f253504f2bd7f3094d8f06c48c4c809"
 
 DEPENDS += "curl libdash libxml2 cjson readline ${@bb.utils.contains('DISTRO_FEATURES', 'build_external_player_interface', 'player-interface', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'webkitbrowser-plugin', '${WPEWEBKIT}', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'subtec', 'closedcaption-hal-headers virtual/vendor-dvb virtual/vendor-closedcaption-hal', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'enable_rialto', 'dobby', '', d)}"
 


### PR DESCRIPTION
Reason for change: Change the order of TuneHelper and MonitorProgress calls, so that progress event with position=0 will be sent before the AAMP starts playback at 1x speed to trigger the PPJS AdRewindController logic
Test Procedure: As mentioned in the ticket
Risks: High