### PR TITLE
RDKMVE-2009 [Realtek] Support the AES-CBC decryption for Playready

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework-ocdm-playready-rdk_git.bb
+++ b/recipes-extended/wpe-framework/wpeframework-ocdm-playready-rdk_git.bb
@@ -5,6 +5,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=19a2b3c39737289f92c7991b16599360"
 
 include recipes-extended/wpe-framework/include/wpeframework-plugins.inc
 
+PR = "r0"
+PV = "1.0.1"
+
 DEPENDS += "  wpeframework wpeframework-clientlibraries wpeframework-tools-native entservices-apis"
 DEPENDS += "  gst-svp-ext gstreamer1.0"
 
@@ -22,7 +25,8 @@ TOOLCHAIN = "gcc"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 SRC_URI = "git://github.com/rdkcentral/playready-rdk.git;${CMF_GITHUB_SRC_URI_SUFFIX};name=pr-source"
-SRCREV = "1dbf957f4f6a7ce8a2708fa241c189a890fa6e58"
+# TAG version 1.0.1
+SRCREV = "20c6542de0fc6f9037b1673556c3b4082829938c"
 SRCREV_FORMAT = "pr-source pr-header"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change:
1. Updated the playready-rdk revision to 1.0.1 to bring the CBCS playback support.

Test Procedure: Build & CEC Test verified

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com