### PR TITLE
RDKEMW-10284: Migrate stunnel to use P12 cert

### DIFF
--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -5,10 +5,10 @@ LICENSE = "Apache-2.0 & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f36198fb804ffbe39b5b2c336ceef9f8"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
-PV = "5.0.0"
+PV = "5.0.1"
 PR = "r0"
 
-SRCREV = "9facdd3232047da30ee142526166b383780ca9f3"
+SRCREV = "cd2d60123551551f7e58efd7e5de5910007f7863"
 SRC_URI = "${CMF_GITHUB_ROOT}/sysint;${CMF_GITHUB_SRC_URI_SUFFIX};module=.;name=sysint"
 S = "${WORKDIR}/git"
 

--- a/recipes-extended/sysint/sysint_git.bbappend
+++ b/recipes-extended/sysint/sysint_git.bbappend
@@ -56,12 +56,6 @@ do_install:append() {
                sed -i "s|response=|response=${NM_CONNECTIVITY_CHECK_RESPONSE}|g" ${D}${sysconfdir}/NetworkManager/conf.d/nm-connectivity.conf
            fi
     fi
-    if [ "${MACHINE}" = "es1-rtk-xumo" ]; then
-          if [ -f ${D}${base_libdir}/rdk/startStunnel.sh ]; then
-                bbnote "Disabling SHORTS"
-               sed -i 's/`tr181 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.SHORTS.Enable 2>&1 > \/dev\/null`/\"false\"/' ${D}${base_libdir}/rdk/startStunnel.sh
-          fi
-    fi
 }
 
 FILES:${PN} += "${sysconfdir}/udhcpc.vendor_specific"


### PR DESCRIPTION
Reason for change: To integrate SE based device cert for mTls connectivity in stunnel
Test Procedure: Build and verify SHORTS connectivity
Risks: None
Priority: P1