### PR TITLE
RDKEMW-17280: Implemented the Generic logic to find DevNode path using devnum and busnum

### DIFF
--- a/recipes-extended/entservices/entservices-usbdevice.bb
+++ b/recipes-extended/entservices/entservices-usbdevice.bb
@@ -2,13 +2,13 @@ SUMMARY = "ENTServices usbdevice plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-PV = "1.0.3"
+PV = "1.0.3.1"
 PR = "r0"
 
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
-SRCREV = "de9721b90d91970bd94a5ddccee0c2ca34f71aff"
+SRCREV = "711378122dd6420759f24af6267955e94278391f"
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-usbdevice;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://rdkservices.ini \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \


### PR DESCRIPTION
RDKEMW-17280: Implemented the Generic logic to find DevNode path using devnum and busnum
version: minor

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]