### PR TITLE
RDKEMW-18156: Update entservices-apis to 2.7.9.1

### DIFF
--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -1,7 +1,7 @@
 SUMMARY = "entservices-apis"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d8927f3331d2b3e321b7dd1925166d25"
-PV ?= "2.7.3"
+PV ?= "2.7.9.1"
 PR ?= "r0"
 
 inherit python3native cmake pkgconfig
@@ -9,13 +9,13 @@ inherit python3native cmake pkgconfig
 
 DEPENDS = "wpeframework wpeframework-tools-native"
 
-SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name=entservices-apis"
+SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name=entservices-apis;branch=support/8.4.4.0"
 
 SRC_URI += "file://RDKEMW-1007.patch"
 
 
-# Tag 2.7.9
-SRCREV_entservices-apis = "34e1870c8946cffb385165da5f5b9d92cbf4c58a"
+# Tag 2.7.9.1
+SRCREV = "1bf02518ad87bed89463582581538cfd16b5cd21"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
This will pull in ITextTrackCapabilities interface which is missing in the 8.4 branch.
