### PR TITLE
RDKEMW-16580: Switch WPE gamepad to libmanette and backport upstream rumble

### DIFF
--- a/recipes-extended/wpe-webkit/files/2.46/comcast-RDKEMW-16580-Backport-Implement-playEffect-via-libmanette-rumble.patch
+++ b/recipes-extended/wpe-webkit/files/2.46/comcast-RDKEMW-16580-Backport-Implement-playEffect-via-libmanette-rumble.patch
@@ -1,0 +1,231 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Petar Tijanic <petar_tijanic@comcast.com>
+Date: Wed, 6 May 2026 00:00:00 +0000
+Subject: [PATCH] RDKEMW-16580: Implement playEffect by supporting gamepad
+ rumble
+
+Backport of upstream commit 2e1369350dab08147264e9881efbb475e48ee422
+("[GTK] Implement playEffect by supporting gamepad rumble" by
+Simon Pena <spena@igalia.com>, https://bugs.webkit.org/show_bug.cgi?id=309274,
+canonical https://commits.webkit.org/308799@main).
+
+Implemented playEffect (and stopEffects) using libmanette's rumble. This
+gates the effect by checking if the type is supported, then applies the
+right rumble parameters depending on the libmanette version used.
+
+Tested against https://hardwaretester.com/gamepad.
+
+Adapted for WPE 2.46:
+- Use WTFMove in place of WTF::move; the latter alias is not used by the
+  rest of the 2.46 codebase.
+- Use RunLoop::current() and the unnamed RunLoop::Timer constructor.
+  RunLoop::currentSingleton() and the named-timer overload were added
+  after 2.46.
+- Enable defaultGamepadVibrationActuatorEnabled() on PLATFORM(WPE) in
+  addition to PLATFORM(GTK), since the WPE port now uses libmanette
+  for gamepad input (see prior patch in this series, switching the WPE
+  gamepad backend from libwpe to libmanette).
+
+* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
+(WebCore::ManetteGamepad::ManetteGamepad):
+(WebCore::ManetteGamepad::playEffect):
+(WebCore::ManetteGamepad::stopEffects):
+(WebCore::ManetteGamepad::effectDelayTimerFired):
+(WebCore::ManetteGamepad::startRumble):
+(WebCore::ManetteGamepad::effectDurationTimerFired):
+* Source/WebCore/platform/gamepad/manette/ManetteGamepad.h:
+* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp:
+(WebCore::ManetteGamepadProvider::removeGamepadForDevice):
+(WebCore::ManetteGamepadProvider::playEffect):
+(WebCore::ManetteGamepadProvider::stopEffects):
+* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
+(WebKit::defaultGamepadVibrationActuatorEnabled):
+---
+diff --git a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
++++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+@@ -126,6 +126,8 @@
+ ManetteGamepad::ManetteGamepad(ManetteDevice* device, unsigned index)
+     : PlatformGamepad(index)
+     , m_device(device)
++    , m_effectDelayTimer(RunLoop::current(), this, &ManetteGamepad::effectDelayTimerFired)
++    , m_effectDurationTimer(RunLoop::current(), this, &ManetteGamepad::effectDurationTimerFired)
+ {
+     ASSERT(index < 4);
+
+@@ -142,6 +144,9 @@
+     for (auto& value : m_buttonValues)
+         value.setValue(0.0);
+
++    if (manette_device_has_rumble(m_device.get()))
++        m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
++
+     g_signal_connect(device, "button-press-event", G_CALLBACK(onButtonPressEvent), this);
+     g_signal_connect(device, "button-release-event", G_CALLBACK(onButtonReleaseEvent), this);
+     g_signal_connect(device, "absolute-axis-event", G_CALLBACK(onAbsoluteAxisEvent), this);
+@@ -174,6 +179,61 @@
+     ManetteGamepadProvider::singleton().gamepadHadInput(*this, ManetteGamepadProvider::ShouldMakeGamepadsVisible::Yes);
+ }
+
++void ManetteGamepad::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
++{
++    if (!m_supportedEffectTypes.contains(type))
++        return completionHandler(false);
++
++    if (m_effectCompletionHandler)
++        stopEffects({ });
++
++    m_effectCompletionHandler = WTFMove(completionHandler);
++    if (parameters.startDelay) {
++        m_pendingEffectParameters = parameters;
++        m_effectDelayTimer.startOneShot(Seconds::fromMilliseconds(parameters.startDelay));
++        return;
++    }
++
++    startRumble(parameters);
++}
++
++void ManetteGamepad::stopEffects(CompletionHandler<void()>&& completionHandler)
++{
++    m_effectDelayTimer.stop();
++    m_effectDurationTimer.stop();
++    if (m_effectCompletionHandler)
++        m_effectCompletionHandler(false);
++
++    manette_device_rumble(m_device.get(), 0, 0, 0);
++
++    if (completionHandler)
++        completionHandler();
++}
++
++void ManetteGamepad::effectDelayTimerFired()
++{
++    startRumble(std::exchange(m_pendingEffectParameters, { }));
++}
++
++void ManetteGamepad::startRumble(const GamepadEffectParameters& parameters)
++{
++#if LIBMANETTE_CHECK_VERSION(0, 2, 13)
++    manette_device_rumble(m_device.get(), parameters.strongMagnitude, parameters.weakMagnitude, static_cast<guint>(parameters.duration));
++#else
++    manette_device_rumble(m_device.get(), parameters.strongMagnitude * G_MAXUINT16, parameters.weakMagnitude * G_MAXUINT16, static_cast<guint>(parameters.duration));
++#endif
++
++    if (parameters.duration)
++        m_effectDurationTimer.startOneShot(Seconds::fromMilliseconds(parameters.duration));
++    else
++        m_effectCompletionHandler(true);
++}
++
++void ManetteGamepad::effectDurationTimerFired()
++{
++    m_effectCompletionHandler(true);
++}
++
+ } // namespace WebCore
+
+ #endif // ENABLE(GAMEPAD) && OS(LINUX)
+diff --git a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
++++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+@@ -27,10 +27,11 @@
+
+ #if ENABLE(GAMEPAD) && OS(LINUX)
+
++#include "GamepadEffectParameters.h"
+ #include "PlatformGamepad.h"
+
+ #include <libmanette.h>
+-#include <wtf/HashMap.h>
++#include <wtf/RunLoop.h>
+ #include <wtf/glib/GRefPtr.h>
+
+ namespace WebCore {
+@@ -71,17 +72,26 @@
+     ManetteGamepad(ManetteDevice*, unsigned index);
+     virtual ~ManetteGamepad();
+
+-    const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
+-    const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
+-
+     void absoluteAxisChanged(ManetteDevice*, StandardGamepadAxis, double value);
+     void buttonPressedOrReleased(ManetteDevice*, StandardGamepadButton, bool pressed);
+
+ private:
++    const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
++    const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
++    void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
++    void stopEffects(CompletionHandler<void()>&&) final;
++    void effectDelayTimerFired();
++    void effectDurationTimerFired();
++    void startRumble(const GamepadEffectParameters&);
++
+     GRefPtr<ManetteDevice> m_device;
+
+     Vector<SharedGamepadValue> m_buttonValues;
+     Vector<SharedGamepadValue> m_axisValues;
++    RunLoop::Timer m_effectDelayTimer;
++    RunLoop::Timer m_effectDurationTimer;
++    CompletionHandler<void(bool)> m_effectCompletionHandler;
++    GamepadEffectParameters m_pendingEffectParameters;
+ };
+
+ } // namespace WebCore
+diff --git a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
+--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
++++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
+@@ -190,22 +190,35 @@
+     ASSERT(result);
+
+     auto index = m_gamepadVector.find(result.get());
+-    if (index != notFound)
++    if (index != notFound) {
++        auto gamepad = m_gamepadVector[index];
++        gamepad->stopEffects({ });
+         m_gamepadVector[index] = nullptr;
++    }
+
+     return result;
+ }
+
+-void ManetteGamepadProvider::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
++void ManetteGamepadProvider::playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+ {
+-    // Not supported by this provider.
+-    completionHandler(false);
++    if (gamepadIndex >= m_gamepadVector.size())
++        return completionHandler(false);
++    auto gamepad = m_gamepadVector[gamepadIndex];
++    if (!gamepad || gamepad->id() != gamepadID)
++        return completionHandler(false);
++
++    gamepad->playEffect(type, parameters, WTFMove(completionHandler));
+ }
+
+-void ManetteGamepadProvider::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
++void ManetteGamepadProvider::stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&& completionHandler)
+ {
+-    // Not supported by this provider.
+-    completionHandler();
++    if (gamepadIndex >= m_gamepadVector.size())
++        return completionHandler();
++    auto gamepad = m_gamepadVector[gamepadIndex];
++    if (!gamepad || gamepad->id() != gamepadID)
++        return completionHandler();
++
++    gamepad->stopEffects(WTFMove(completionHandler));
+ }
+
+ } // namespace WebCore
+diff --git a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
++++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+@@ -271,7 +271,7 @@
+ #if ENABLE(GAMEPAD)
+ bool defaultGamepadVibrationActuatorEnabled()
+ {
+-#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
++#if HAVE(WIDE_GAMECONTROLLER_SUPPORT) || PLATFORM(GTK) || PLATFORM(WPE)
+     return true;
+ #else
+     return false;

--- a/recipes-extended/wpe-webkit/files/2.46/comcast-RDKEMW-16580-WPE-Switch-gamepad-backend-from-libwpe-to-libmanette.patch
+++ b/recipes-extended/wpe-webkit/files/2.46/comcast-RDKEMW-16580-WPE-Switch-gamepad-backend-from-libwpe-to-libmanette.patch
@@ -1,0 +1,164 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Petar Tijanic <petar_tijanic@comcast.com>
+Date: Wed, 6 May 2026 00:00:00 +0000
+Subject: [PATCH] RDKEMW-16580: [WPE] Switch gamepad backend from libwpe to
+ libmanette
+
+Switch the WPE port to use libmanette as the gamepad backend, matching what
+the GTK port already does. This is a prerequisite for backporting upstream
+gamepad rumble/haptic support (commit 2e1369350dab) to WPE 2.46.
+
+Drops the libwpe-based GamepadProvider/UIGamepadProvider from the WPE
+build, wires up the Manette equivalents in WebCore and WebKit, and adapts
+WPEWebViewLegacy::platformWebPageProxyForGamepadInput() so it no longer
+depends on GamepadProviderLibWPE::inputView() for view correlation.
+With manette there is no per-view backend, so input is routed to the
+first focused+visible view.
+
+* Source/WebCore/SourcesWPE.txt: Replace libwpe gamepad sources with
+  manette equivalents.
+* Source/WebKit/SourcesWPE.txt: Replace UIGamepadProviderLibWPE.cpp with
+  UIGamepadProviderManette.cpp.
+* Source/WebCore/PlatformWPE.cmake: Use the manette include path,
+  expose ManetteGamepadProvider.h, and link Manette::Manette.
+* Source/cmake/OptionsWPE.cmake: Add find_package(Manette 0.2.4) and
+  SET_AND_EXPOSE_TO_BUILD(USE_MANETTE TRUE) when ENABLE_GAMEPAD is set.
+* Source/WebKit/UIProcess/Gamepad/manette/UIGamepadProviderManette.cpp:
+  Add a PLATFORM(WPE) implementation of platformWebPageProxyForGamepadInput()
+  that delegates to WKWPE::ViewLegacy.
+(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
+* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp: Drop the libwpe
+  GamepadProviderLibWPE include and inputView()-driven view selection.
+(WKWPE::ViewLegacy::platformWebPageProxyForGamepadInput):
+---
+diff --git a/Source/WebCore/SourcesWPE.txt b/Source/WebCore/SourcesWPE.txt
+--- a/Source/WebCore/SourcesWPE.txt
++++ b/Source/WebCore/SourcesWPE.txt
+@@ -49,8 +49,8 @@
+ page/linux/ResourceUsageOverlayLinux.cpp
+ page/linux/ResourceUsageThreadLinux.cpp
+
+-platform/gamepad/libwpe/GamepadLibWPE.cpp
+-platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
++platform/gamepad/manette/ManetteGamepad.cpp
++platform/gamepad/manette/ManetteGamepadProvider.cpp
+
+ platform/generic/ScrollbarsControllerGeneric.cpp
+
+diff --git a/Source/WebKit/SourcesWPE.txt b/Source/WebKit/SourcesWPE.txt
+--- a/Source/WebKit/SourcesWPE.txt
++++ b/Source/WebKit/SourcesWPE.txt
+@@ -220,7 +220,7 @@
+
+ UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+
+-UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp
++UIProcess/Gamepad/manette/UIGamepadProviderManette.cpp
+
+ UIProcess/geoclue/GeoclueGeolocationProvider.cpp
+
+diff --git a/Source/WebKit/UIProcess/Gamepad/manette/UIGamepadProviderManette.cpp b/Source/WebKit/UIProcess/Gamepad/manette/UIGamepadProviderManette.cpp
+--- a/Source/WebKit/UIProcess/Gamepad/manette/UIGamepadProviderManette.cpp
++++ b/Source/WebKit/UIProcess/Gamepad/manette/UIGamepadProviderManette.cpp
+@@ -32,6 +32,10 @@
+ #include <WebCore/ManetteGamepadProvider.h>
+ #include <wtf/ProcessPrivilege.h>
+
++#if PLATFORM(WPE)
++#include "WPEWebViewLegacy.h"
++#endif
++
+ namespace WebKit {
+
+ using namespace WebCore;
+@@ -47,7 +51,11 @@
+ #if !PLATFORM(GTK)
+ WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
+ {
++#if PLATFORM(WPE)
++    return WKWPE::ViewLegacy::platformWebPageProxyForGamepadInput();
++#else
+     return nullptr;
++#endif
+ }
+ #endif
+
+diff --git a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
+--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
++++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
+@@ -38,10 +38,6 @@
+ #include <wpe/wpe.h>
+ #include <wtf/NeverDestroyed.h>
+
+-#if ENABLE(GAMEPAD)
+-#include <WebCore/GamepadProviderLibWPE.h>
+-#endif
+-
+ using namespace WebKit;
+
+ namespace WKWPE {
+@@ -389,22 +385,10 @@
+     if (views.isEmpty())
+         return nullptr;
+
+-    struct wpe_view_backend* viewBackend = WebCore::GamepadProviderLibWPE::singleton().inputView();
+-
+-    size_t index = notFound;
+-
+-    if (viewBackend) {
+-        index = views.findIf([&](ViewLegacy* view) {
+-            return view->backend() == viewBackend
+-                && view->viewState().contains(WebCore::ActivityState::IsVisible)
+-                && view->viewState().contains(WebCore::ActivityState::IsFocused);
+-        });
+-    } else {
+-        index = views.findIf([](ViewLegacy* view) {
+-            return view->viewState().contains(WebCore::ActivityState::IsVisible)
+-                && view->viewState().contains(WebCore::ActivityState::IsFocused);
+-        });
+-    }
++    auto index = views.findIf([](ViewLegacy* view) {
++        return view->viewState().contains(WebCore::ActivityState::IsVisible)
++            && view->viewState().contains(WebCore::ActivityState::IsFocused);
++    });
+
+     if (index != notFound)
+         return &(views[index]->page());
+diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
+--- a/Source/cmake/OptionsWPE.cmake
++++ b/Source/cmake/OptionsWPE.cmake
+@@ -232,6 +232,14 @@
+     message(FATAL_ERROR "libwpe>=1.16.2 is required for ENABLE_GAMEPAD")
+ endif ()
+
++if (ENABLE_GAMEPAD)
++    find_package(Manette 0.2.4)
++    if (NOT Manette_FOUND)
++        message(FATAL_ERROR "libmanette is required for ENABLE_GAMEPAD")
++    endif ()
++    SET_AND_EXPOSE_TO_BUILD(USE_MANETTE TRUE)
++endif ()
++
+ if (ENABLE_SPEECH_SYNTHESIS)
+     if (USE_FLITE)
+         if (USE_TTS_CLIENT)
+diff --git a/Source/WebCore/PlatformWPE.cmake b/Source/WebCore/PlatformWPE.cmake
+--- a/Source/WebCore/PlatformWPE.cmake
++++ b/Source/WebCore/PlatformWPE.cmake
+@@ -136,11 +136,14 @@
+
+ if (ENABLE_GAMEPAD)
+     list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+-        "${WEBCORE_DIR}/platform/gamepad/libwpe"
++        "${WEBCORE_DIR}/platform/gamepad/manette"
+     )
+
+     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+-        platform/gamepad/libwpe/GamepadProviderLibWPE.h
++        platform/gamepad/manette/ManetteGamepadProvider.h
++    )
++    list(APPEND WebCore_LIBRARIES
++        Manette::Manette
+     )
+ endif ()
+

--- a/recipes-extended/wpe-webkit/files/2.46/comcast-RDKEMW-18589-WPE-Add-analog-trigger-support-via-libmanette.patch
+++ b/recipes-extended/wpe-webkit/files/2.46/comcast-RDKEMW-18589-WPE-Add-analog-trigger-support-via-libmanette.patch
@@ -1,0 +1,106 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Petar Tijanic <petar_tijanic@comcast.com>
+Date: Mon, 18 May 2026 00:00:00 +0000
+Subject: [PATCH] RDKEMW-18589: [WPE] Add analog trigger support to the
+ libmanette gamepad backend
+
+Backports analog trigger value reporting to the libmanette-based WPE
+gamepad path that was introduced by RDKEMW-16580. Mirrors the binary-vs-
+analog split that GamepadLibWPE already uses on the libwpe path:
+a separate analogButtonChanged() method handles continuous 0..1 trigger
+values while buttonPressedOrReleased() remains the digital 1.0 / 0.0 path.
+
+The analog source data is already produced by the comcast libmanette
+downstream patch
+  meta-rdk-oss-reference/recipes-extended/libmanette/files/
+    0003-button-values-for-gas-brake.patch
+which exposes manette_event_get_button_value() -- a 0.0..1.0 normalized
+value attached to MANETTE_EVENT_BUTTON_PRESS / RELEASE events whose
+source is an analog axis (real analog triggers).
+
+For LeftTrigger / RightTrigger the on*Event callbacks pull the analog
+value and route it through analogButtonChanged(), which clamps and
+writes it to m_buttonValues -- exactly the libwpe pattern. All other
+buttons stay on the binary buttonPressedOrReleased() path.
+
+libmanette equivalent of upstream libwpe PRs:
+  WebPlatformForEmbedded/libwpe#134 (analog button callback)
+  WebPlatformForEmbedded/libwpe#135 (ABI fix-up)
+and matching WPEWebKit PR #1442 (GamepadLibWPE::analogButtonChanged).
+
+* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
+(WebCore::onButtonPressEvent):
+(WebCore::onButtonReleaseEvent):
+(WebCore::ManetteGamepad::analogButtonChanged):
+* Source/WebCore/platform/gamepad/manette/ManetteGamepad.h:
+---
+diff --git a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
++++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+@@ -111,7 +111,19 @@
+     if (!manette_event_get_button(event, &button))
+         return;
+
+-    gamepad->buttonPressedOrReleased(device, toStandardGamepadButton(button), true);
++    auto standardButton = toStandardGamepadButton(button);
++    // L2 / R2 carry an analog 0..1 value via the comcast libmanette patch
++    // (manette_event_get_button_value). Route them through the analog path,
++    // mirroring how GamepadLibWPE splits binary vs analog button events.
++    if (standardButton == ManetteGamepad::StandardGamepadButton::LeftTrigger
++        || standardButton == ManetteGamepad::StandardGamepadButton::RightTrigger) {
++        gdouble value = 1.0;
++        if (manette_event_get_button_value(event, &value) && value > 0.0) {
++            gamepad->analogButtonChanged(device, standardButton, value);
++            return;
++        }
++    }
++    gamepad->buttonPressedOrReleased(device, standardButton, true);
+ }
+
+ static void onButtonReleaseEvent(ManetteDevice* device, ManetteEvent* event, ManetteGamepad* gamepad)
+@@ -120,7 +132,15 @@
+     if (!manette_event_get_button(event, &button))
+         return;
+
+-    gamepad->buttonPressedOrReleased(device, toStandardGamepadButton(button), false);
++    auto standardButton = toStandardGamepadButton(button);
++    if (standardButton == ManetteGamepad::StandardGamepadButton::LeftTrigger
++        || standardButton == ManetteGamepad::StandardGamepadButton::RightTrigger) {
++        gdouble value = 0.0;
++        manette_event_get_button_value(event, &value);
++        gamepad->analogButtonChanged(device, standardButton, value);
++        return;
++    }
++    gamepad->buttonPressedOrReleased(device, standardButton, false);
+ }
+
+ ManetteGamepad::ManetteGamepad(ManetteDevice* device, unsigned index)
+@@ -168,6 +188,17 @@
+     ManetteGamepadProvider::singleton().gamepadHadInput(*this, pressed ? ManetteGamepadProvider::ShouldMakeGamepadsVisible::Yes : ManetteGamepadProvider::ShouldMakeGamepadsVisible::No);
+ }
+
++void ManetteGamepad::analogButtonChanged(ManetteDevice*, StandardGamepadButton button, double value)
++{
++    if (button == StandardGamepadButton::Unknown)
++        return;
++
++    m_lastUpdateTime = MonotonicTime::now();
++    m_buttonValues[static_cast<int>(button)].setValue(clampTo(value, 0.0, 1.0));
++
++    ManetteGamepadProvider::singleton().gamepadHadInput(*this, ManetteGamepadProvider::ShouldMakeGamepadsVisible::Yes);
++}
++
+ void ManetteGamepad::absoluteAxisChanged(ManetteDevice*, StandardGamepadAxis axis, double value)
+ {
+     if (axis == StandardGamepadAxis::Unknown)
+diff --git a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
++++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+@@ -74,6 +74,7 @@
+
+     void absoluteAxisChanged(ManetteDevice*, StandardGamepadAxis, double value);
+     void buttonPressedOrReleased(ManetteDevice*, StandardGamepadButton, bool pressed);
++    void analogButtonChanged(ManetteDevice*, StandardGamepadButton, double value);
+
+ private:
+     const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.1.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.1.bb
@@ -7,7 +7,7 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance with every change in the recipe. Must be a plain integer (no dots, letters, etc.)
-WPE_RECIPE_REVISION = "2"
+WPE_RECIPE_REVISION = "3"
 
 PR = "r${WPE_RECIPE_REVISION}"
 # Micro version suffix - four digits XXYY (XX - PV.micro, YY - WPE_RECIPE_REVISION)
@@ -59,6 +59,9 @@ SRC_URI += "file://2.46/comcast-WebRTC-keep-render-time-interpolation.patch"
 SRC_URI += "file://2.46/comcast-DELIA-59087-Disable-pausing-playback-for-buf.patch"
 SRC_URI += "file://2.46/comcast-RDKTV-28214-Quick-_exit.patch"
 #SRC_URI += "file://2.46/comcast-RDK-37379-Mute-release-logging.patch"
+SRC_URI += "file://2.46/comcast-RDKEMW-16580-WPE-Switch-gamepad-backend-from-libwpe-to-libmanette.patch"
+SRC_URI += "file://2.46/comcast-RDKEMW-16580-Backport-Implement-playEffect-via-libmanette-rumble.patch"
+SRC_URI += "file://2.46/comcast-RDKEMW-18589-WPE-Add-analog-trigger-support-via-libmanette.patch"
 
 PACKAGECONFIG[atk]                   = "-DUSE_ATK=ON,-DUSE_ATK=OFF,at-spi2-atk,"
 PACKAGECONFIG[accessibility]         = "-DUSE_ATSPI=ON,-DUSE_ATSPI=OFF,rdkat-atspi2,rdkat-atspi2"
@@ -99,6 +102,7 @@ PACKAGECONFIG[wpeqtapi]              = "-DENABLE_WPE_QT_API=ON,-DENABLE_WPE_QT_A
 PACKAGECONFIG[cairo]                 = "-DUSE_CAIRO=ON -DUSE_SKIA=OFF,-DUSE_CAIRO=OFF,cairo"
 PACKAGECONFIG[externalholepunch]     = "-DUSE_EXTERNAL_HOLEPUNCH=ON,-DUSE_EXTERNAL_HOLEPUNCH=OFF,"
 PACKAGECONFIG[ftrace]                = "-DUSE_LINUX_FTRACE=ON,-DUSE_LINUX_FTRACE=OFF,"
+PACKAGECONFIG[gamepad]               = "-DENABLE_GAMEPAD=ON,-DENABLE_GAMEPAD=OFF,libmanette,"
 
 # Config options are no longer available in 2.46
 PACKAGECONFIG[2dcanvas]     = ""

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
@@ -7,7 +7,7 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r37"
+PR  = "r38"
 
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
 DEPENDS:append = " libtasn1 unifdef-native libsoup libepoxy libgcrypt fontconfig"
@@ -56,6 +56,7 @@ SRC_URI += "file://2.46/comcast-WebRTC-keep-render-time-interpolation.patch"
 SRC_URI += "file://2.46/comcast-DELIA-59087-Disable-pausing-playback-for-buf.patch"
 SRC_URI += "file://2.46/comcast-RDKTV-28214-Quick-_exit.patch"
 #SRC_URI += "file://2.46/comcast-RDK-37379-Mute-release-logging.patch"
+SRC_URI += "file://2.46/comcast-RDKEMW-16580-WPE-Switch-gamepad-backend-from-libwpe-to-libmanette.patch"
 
 PACKAGECONFIG[atk]                   = "-DUSE_ATK=ON,-DUSE_ATK=OFF,at-spi2-atk,"
 PACKAGECONFIG[accessibility]         = "-DUSE_ATSPI=ON,-DUSE_ATSPI=OFF,rdkat-atspi2,rdkat-atspi2"
@@ -95,6 +96,7 @@ PACKAGECONFIG[wpeqtapi]              = "-DENABLE_WPE_QT_API=ON,-DENABLE_WPE_QT_A
 PACKAGECONFIG[cairo]                 = "-DUSE_CAIRO=ON -DUSE_SKIA=OFF,-DUSE_CAIRO=OFF,cairo"
 PACKAGECONFIG[externalholepunch]     = "-DUSE_EXTERNAL_HOLEPUNCH=ON,-DUSE_EXTERNAL_HOLEPUNCH=OFF,"
 PACKAGECONFIG[ftrace]                = "-DUSE_LINUX_FTRACE=ON,-DUSE_LINUX_FTRACE=OFF,"
+PACKAGECONFIG[gamepad]               = "-DENABLE_GAMEPAD=ON,-DENABLE_GAMEPAD=OFF,libmanette,"
 
 # Config options are no longer available in 2.46
 PACKAGECONFIG[2dcanvas]     = ""

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
@@ -58,6 +58,7 @@ SRC_URI += "file://2.46/comcast-RDKTV-28214-Quick-_exit.patch"
 #SRC_URI += "file://2.46/comcast-RDK-37379-Mute-release-logging.patch"
 SRC_URI += "file://2.46/comcast-RDKEMW-16580-WPE-Switch-gamepad-backend-from-libwpe-to-libmanette.patch"
 SRC_URI += "file://2.46/comcast-RDKEMW-16580-Backport-Implement-playEffect-via-libmanette-rumble.patch"
+SRC_URI += "file://2.46/comcast-RDKEMW-18589-WPE-Add-analog-trigger-support-via-libmanette.patch"
 
 PACKAGECONFIG[atk]                   = "-DUSE_ATK=ON,-DUSE_ATK=OFF,at-spi2-atk,"
 PACKAGECONFIG[accessibility]         = "-DUSE_ATSPI=ON,-DUSE_ATSPI=OFF,rdkat-atspi2,rdkat-atspi2"

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.bb
@@ -7,7 +7,7 @@ PATCHTOOL = "git"
 require wpe-webkit.inc
 
 # Advance PR with every change in the recipe
-PR  = "r38"
+PR  = "r39"
 
 DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
 DEPENDS:append = " libtasn1 unifdef-native libsoup libepoxy libgcrypt fontconfig"
@@ -57,6 +57,7 @@ SRC_URI += "file://2.46/comcast-DELIA-59087-Disable-pausing-playback-for-buf.pat
 SRC_URI += "file://2.46/comcast-RDKTV-28214-Quick-_exit.patch"
 #SRC_URI += "file://2.46/comcast-RDK-37379-Mute-release-logging.patch"
 SRC_URI += "file://2.46/comcast-RDKEMW-16580-WPE-Switch-gamepad-backend-from-libwpe-to-libmanette.patch"
+SRC_URI += "file://2.46/comcast-RDKEMW-16580-Backport-Implement-playEffect-via-libmanette-rumble.patch"
 
 PACKAGECONFIG[atk]                   = "-DUSE_ATK=ON,-DUSE_ATK=OFF,at-spi2-atk,"
 PACKAGECONFIG[accessibility]         = "-DUSE_ATSPI=ON,-DUSE_ATSPI=OFF,rdkat-atspi2,rdkat-atspi2"


### PR DESCRIPTION
Brings gamepad rumble / haptic feedback (`GamepadHapticActuator.playEffect`)
to the WPE port on WebKit 2.46. Two commits:

1. **Switch WPE gamepad backend from libwpe to libmanette** — aligns WPE
   with what GTK already does, drops `GamepadProviderLibWPE` /
   `UIGamepadProviderLibWPE` from the WPE build, wires up the manette
   equivalents, and adds `find_package(Manette 0.2.4)` in `OptionsWPE.cmake`.
   Required as a prerequisite for commit 2.

2. **Backport upstream `2e1369350dab`** — implements `playEffect` /
   `stopEffects` on top of `libmanette`'s rumble API. Direct cherry-pick
   of the upstream change with three small adaptations for 2.46:
   - `WTFMove` instead of `WTF::move`
   - `RunLoop::current()` + unnamed `RunLoop::Timer` ctor (2.46 predates
     `RunLoop::currentSingleton()` and the named-timer overload)
   - Vibration actuator default also enabled for `PLATFORM(WPE)` since
     commit 1 puts WPE on libmanette