### PR TITLE
RDKEMW-18275: replace systemservice comrpc

### DIFF
--- a/recipes-extended/entservices/entservices-devicediagnostics.bb
+++ b/recipes-extended/entservices/entservices-devicediagnostics.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-devicediagnostics;${CMF_GITHUB_SRC_URI
           "
 
 # Release version - 1.2.2
-SRCREV = "16de54e86bc798cb7ad4435ba76634acc9a0462e"
+SRCREV = "e8af97ec9e21a74469534f1084043538ad3f6b8a"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/entservices/entservices-mediaanddrm.bb
+++ b/recipes-extended/entservices/entservices-mediaanddrm.bb
@@ -18,7 +18,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-mediaanddrm;${CMF_GITHUB_SRC_URI_SUFFI
           "
           
 # Release version - 1.8.2
-SRCREV = "80b69d25d3177d041a552617b4cd804998f29866"
+SRCREV = "cb2070f519e9905129f0c94856224b199042bbf8"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/entservices/entservices-systemservices.bb
+++ b/recipes-extended/entservices/entservices-systemservices.bb
@@ -14,7 +14,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-systemservices;${CMF_GITHUB_SRC_URI_SU
           "
 
 # Release version - 1.5.0
-SRCREV = "bcfe28c12f3aced6c9a8e27fa69bccd721b623c2"
+SRCREV = "a13e0cebfa0ab369ded7e51957d58c24b9dcfb3d"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/thunderstartupservices/thunderstartupservices.bb
+++ b/recipes-extended/thunderstartupservices/thunderstartupservices.bb
@@ -10,7 +10,7 @@ PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 DEPENDS = "systemd"
 
-SRCREV = "68ae8971ed2e0c982b8643454efc0bbd72f517fd"
+SRCREV = "fc6246733a30e5cbd3ac17abc09f74651b5dd690"
 SRC_URI = "git://github.com/rdkcentral/thunder-startup-services.git;protocol=git;name=thunderstartupservices \
     ${@bb.utils.contains('DISTRO_FEATURES', 'RDKE_PLATFORM_TV', 'file://0002-displaysettings-tv-deps.patch', '', d)} \
 "

--- a/recipes-extended/wpe-framework/entservices-apis.bb
+++ b/recipes-extended/wpe-framework/entservices-apis.bb
@@ -16,7 +16,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-apis;${CMF_GITHUB_SRC_URI_SUFFIX};name
 SRC_URI += "file://RDKEMW-1007.patch"
 
 # Tag 3.6.4
-SRCREV_entservices-apis = "ed34c173df1757e1793b9b671655a67a644d86b4"
+SRCREV_entservices-apis = "ef7a2ef2f7854098ed690e268d55a040e9967d44"
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: tts changes to use comrpc for system service
Test Procedure: Mentioned in ticket
Risks: Low
version: minor