### PR TITLE
RDKEMW-18291: Remove userland dependency in RPI4 Middleware build.

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
@@ -117,8 +117,6 @@ INSANE_SKIP:${PN}-dbg += "dev-so"
 
 # ----------------------------------------------------------------------------
 
-RDEPENDS:${PN}:append:rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'userland', d)}"
-
 CXXFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'netflix_cryptanium', " -I${STAGING_INCDIR}/secapi-crypto/sec_api/headers", "", d)}"
 
 # Avoid settings ADNEEDED in LDFLAGS as this can cause the libcompositor.so to drop linking to libEGL/libGLES

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -210,12 +210,9 @@ INSANE_SKIP:${PN}-dbg += "dev-so"
 
 # ----------------------------------------------------------------------------
 
-RDEPENDS:${PN}_rpi = "userland"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'rdk_svp', 'gst-svp-ext', '', d)}"
 # Should be able to remove this when generic rdk_svp flag
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'sage_svp', 'gst-svp-ext', '', d)}"
-
-RDEPENDS:${PN}:append:rpi = " ${@bb.utils.contains('DISTRO_FEATURES', 'vc4graphics', '', 'userland', d)}"
 
 inherit breakpad-logmapper syslog-ng-config-gen logrotate_config
 

--- a/recipes-thunder/thunder/wpeframework-clientlibraries_5.3.bb
+++ b/recipes-thunder/thunder/wpeframework-clientlibraries_5.3.bb
@@ -91,8 +91,6 @@ INSANE_SKIP:${PN}-dbg += "dev-so"
 
 # ----------------------------------------------------------------------------
 
-RDEPENDS:${PN}:append:rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'userland', d)}"
-
 CXXFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'netflix_cryptanium', " -I${STAGING_INCDIR}/secapi-crypto/sec_api/headers", "", d)}"
 
 # Avoid settings ADNEEDED in LDFLAGS as this can cause the libcompositor.so to drop linking to libEGL/libGLES

--- a/recipes-thunder/thunder/wpeframework_5.3.bb
+++ b/recipes-thunder/thunder/wpeframework_5.3.bb
@@ -102,9 +102,6 @@ INSANE_SKIP:${PN}-dbg += "dev-so"
 
 # ----------------------------------------------------------------------------
 
-RDEPENDS:${PN}_rpi = "userland"
-RDEPENDS:${PN}:append:rpi = " ${@bb.utils.contains('DISTRO_FEATURES', 'vc4graphics', '', 'userland', d)}"
-
 inherit breakpad-logmapper syslog-ng-config-gen logrotate_config
 
 SYSLOG-NG_FILTER = "thunder"


### PR DESCRIPTION
**Reason for change:** Recently we Refactor DSHAL implementation to align with V4L2, DRM/KMS and Mesa instead of Userland. So, we removed the Userland Dependency from Vendor layer. So, now we need to remove dependency in MW layer also. 
**Test Procedure:** Build and verify.
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com