### PR TITLE
RDKEMW-18116: Align player interface component to Aamp federated release2604

### DIFF
--- a/recipes-extended/aamp/aamp_git.bb
+++ b/recipes-extended/aamp/aamp_git.bb
@@ -7,7 +7,7 @@ PV ?= "3.3.0"
 PR ?= "r0"
 
 SRCREV_FORMAT = "aamp"
-SRCREV_aamp ?= "32ffcb2f9ba33838d243954abca53a9195cc2762"
+SRCREV_aamp ?= "d16ce0e9f1d28c2afd36831576c893b633844478"
 
 # Support to build from a different branch by overriding both AAMP_BRANCH and SRCREV_aamp to specific branch and revision.
 AAMP_BRANCH ?= "develop"

--- a/recipes-extended/player-interface/player-interface_git.bb
+++ b/recipes-extended/player-interface/player-interface_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=97dd37dbf35103376811825b038fc32b"
 PV = "0.1.3"
 PR = "r0"
 
-SRCREV = "99d9f9642676457e8032a048c72d891c468f0aae"
+SRCREV = "8a0af757b14063c7937828b738c7f12671b88f18"
 # Support to build from a different branch by overriding both PLAYERINTERFACE_BRANCH and SRCREV to specific branch and revision.
 PLAYERINTERFACE_BRANCH ?= "main"
 


### PR DESCRIPTION
Reason for change: Align player interface component to Aamp federated release2604

Test Procedure: All Aamp playback should work fine 
Priority: P1
Risks: None