### PR TITLE
RDK-60535: wpe-webkit 2.46.1

### DIFF
--- a/recipes-extended/wpe-webkit/files/2.46.1/1654_USAC_gst_query.patch
+++ b/recipes-extended/wpe-webkit/files/2.46.1/1654_USAC_gst_query.patch
@@ -1,0 +1,37 @@
+From d8522c27441c0faf0f024c41adaddf59d4258da3 Mon Sep 17 00:00:00 2001
+From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+Date: Tue, 5 May 2026 10:51:42 +0200
+Subject: [PATCH] [GStreamer] Auto-detect USAC support via GStreamer registry
+
+Add a fallback check for USAC (xHE-AAC) codec support by probing
+the GStreamer registry for a decoder matching
+"audio/mpeg, mpegversion=(int)4, stream-format=(string)usac".
+
+The stream-format=usac caps field is not part of the standard GStreamer
+audio/mpeg caps definition, but some custom audio sinks advertise it, so it can
+be used as an indicator of USAC decoding capability.
+
+The WEBKIT_GST_CAN_PLAY_USAC environment variable still takes
+precedence as a manual override.
+---
+ .../platform/graphics/gstreamer/GStreamerRegistryScanner.cpp  | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+index aa5ab6870b66..5f625abbbd96 100644
+--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
++++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+@@ -499,6 +499,10 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
+         // USAC AOT, is not yet widely available enough to be enabled by default.
+         const char* value = g_getenv("WEBKIT_GST_CAN_PLAY_USAC");
+         bool canPlayUsac = value && (!g_strcmp0(value, "true") || !g_strcmp0(value, "1"));
++        if (!value) {
++            // Env is not set. Fall back to gst elements query
++            canPlayUsac = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)4, stream-format=(string)usac"_s).isSupported;
++        }
+         if (canPlayUsac)
+             m_decoderCodecMap.add("mp4a.40.42"_s, result); // MPEG-4 Extended HE-AAC and xHE-AAC (USAC AOT)
+     }
+-- 
+2.51.0
+

--- a/recipes-extended/wpe-webkit/files/2.46.1/comcast-RDK-60535-Increase-minor-version-of-WPE-lib.patch
+++ b/recipes-extended/wpe-webkit/files/2.46.1/comcast-RDK-60535-Increase-minor-version-of-WPE-lib.patch
@@ -1,0 +1,28 @@
+From b9c25e0249cc58babba8e5f18814d18ac3f40a60 Mon Sep 17 00:00:00 2001
+From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+Date: Tue, 5 May 2026 11:16:33 +0200
+Subject: [PATCH] comcast - RDK-60535 - Increase minor version of WPE lib
+
+---
+ Source/cmake/OptionsWPE.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
+index 93e358f791ee..8d45333c16a3 100644
+--- a/Source/cmake/OptionsWPE.cmake
++++ b/Source/cmake/OptionsWPE.cmake
+@@ -194,9 +194,9 @@ endif ()
+ find_package(GLIB ${GLIB_MINIMUM_VERSION} REQUIRED COMPONENTS gio gio-unix gobject gthread gmodule)
+ 
+ if (WPE_API_VERSION VERSION_EQUAL "1.1")
+-    CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(WEBKIT 8 11 8)
++    CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(WEBKIT 8 12 8)
+ else ()
+-    CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(WEBKIT 5 11 4)
++    CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(WEBKIT 5 12 4)
+ endif ()
+ 
+ if (ENABLE_WPE_PLATFORM)
+-- 
+2.51.0
+

--- a/recipes-extended/wpe-webkit/wpe-webkit_2.46.1.bb
+++ b/recipes-extended/wpe-webkit/wpe-webkit_2.46.1.bb
@@ -1,0 +1,146 @@
+inherit features_check
+REQUIRED_DISTRO_FEATURES = "enable_libsoup3"
+DEFAULT_PREFERENCE = "-1"
+
+PATCHTOOL = "git"
+
+require wpe-webkit.inc
+
+# Advance with every change in the recipe. Must be a plain integer (no dots, letters, etc.)
+WPE_RECIPE_REVISION = "0"
+
+PR = "r${WPE_RECIPE_REVISION}"
+# Micro version suffix - four digits XXYY (XX - PV.micro, YY - WPE_RECIPE_REVISION)
+WPE_MICRO_VERSION_SUFFIX = "${@'%02d%02d' % (int((d.getVar('PV').split('.') + ['0'])[2]), int(d.getVar('WPE_RECIPE_REVISION')))}"
+
+DEPENDS:append = " virtual/vendor-secapi2-adapter virtual/vendor-gst-drm-plugins "
+DEPENDS:append = " libtasn1 unifdef-native libsoup libepoxy libgcrypt fontconfig"
+PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
+
+# Tip of the branch on May 11, 2026
+SRCREV = "5249e54482622fda0590165ce278d8a7f171be2d"
+
+BASE_URI ?= "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=http;branch=wpe-2.46"
+SRC_URI = "${BASE_URI}"
+
+# Drop after PR is accepted
+SRC_URI += "file://2.46/1629.patch"
+SRC_URI += "file://2.46.1/1654_USAC_gst_query.patch"
+
+# Drop after westeros change is approved and released
+SRC_URI += "file://2.46/comcast-RDK-58780-set-segment-position-field.patch"
+
+# Comcast specific changes
+SRC_URI += "file://2.46.1/comcast-RDK-60535-Increase-minor-version-of-WPE-lib.patch"
+
+SRC_URI += "file://2.46/comcast-RDKTV-380-disable-privileges-loss.patch"
+SRC_URI += "file://2.46/comcast-WKIT-553-add-video-ave-mimetype-for-holepunc.patch"
+SRC_URI += "file://2.46/comcast-AMLOGIC-628-always-initialze-volume.patch"
+SRC_URI += "file://2.46/comcast-RDK-57261-Disable-optional-parser.patch"
+SRC_URI += "file://2.46/comcast-RDK-57741-sleep-150-microsecs-instead-of-s.patch"
+SRC_URI += "file://2.46/comcast-RDK-56287-rdkat-atspi2.patch"
+SRC_URI += "file://2.46/comcast-RDK-57771-Flush-AppendPipeline-resetParserState.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-Increase-html-parser-time-limit.patch"
+SRC_URI += "file://2.46/comcast-RDKTV-1411-force-stop-media-on-loading-about.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-Secure-minidump-path.patch"
+SRC_URI += "file://2.46/comcast-RDKTV-6665-Remove-screen-saver-disabler.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-Support-for-external-sink-x-dvb.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-scan-decoder-elements-on-Broadcom.patch"
+SRC_URI += "file://2.46/comcast-RDKTV-17281-RDKTV-17781-Workaround-for-AppleTV-rendering.patch"
+SRC_URI += "file://2.46/comcast-RDKTV-18852-Restrict-inspection-of-locally-hosted-pages.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-Analyze-higher-CPU-usage.patch"
+SRC_URI += "file://2.46/comcast-RDK-40634-Only-support-decoders-with-hw-support-for-webrtc.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-Include-HW-secure-decrypt-WidevineL1.patch"
+SRC_URI += "file://2.46/comcast-RDK-58053-MSE-skip-seek-to-duration-if-player-not-loaded.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-Fix-init-data-filtering.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-log-HTML5-video-playback.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-EME-generate-MEDIA_ERR_ENCRYPTED.patch"
+SRC_URI += "file://2.46/comcast-RDK-57915-Track-encrypted-playback.patch"
+SRC_URI += "file://2.46/comcast-WebRTC-keep-render-time-interpolation.patch"
+SRC_URI += "file://2.46/comcast-DELIA-59087-Disable-pausing-playback-for-buf.patch"
+SRC_URI += "file://2.46/comcast-RDKTV-28214-Quick-_exit.patch"
+#SRC_URI += "file://2.46/comcast-RDK-37379-Mute-release-logging.patch"
+
+PACKAGECONFIG[atk]                   = "-DUSE_ATK=ON,-DUSE_ATK=OFF,at-spi2-atk,"
+PACKAGECONFIG[accessibility]         = "-DUSE_ATSPI=ON,-DUSE_ATSPI=OFF,rdkat-atspi2,rdkat-atspi2"
+PACKAGECONFIG[asan]                  = "-DENABLE_SANITIZERS=address,,gcc-sanitizers"
+PACKAGECONFIG[avif]                  = "-DUSE_AVIF=ON,-DUSE_AVIF=OFF,"
+PACKAGECONFIG[bubblewrapsandbox]     = "-DENABLE_BUBBLEWRAP_SANDBOX=ON,-DENABLE_BUBBLEWRAP_SANDBOX=OFF,"
+PACKAGECONFIG[developermode]         = "-DDEVELOPER_MODE=ON -DENABLE_COG=OFF,-DDEVELOPER_MODE=OFF,wpebackend-fdo wayland-native,"
+PACKAGECONFIG[documentation]         = "-DENABLE_DOCUMENTATION=ON,-DENABLE_DOCUMENTATION=OFF, gi-docgen-native gi-docgen"
+PACKAGECONFIG[encryptedmedia]        = "-DENABLE_ENCRYPTED_MEDIA=ON,-DENABLE_ENCRYPTED_MEDIA=OFF,"
+PACKAGECONFIG[experimental]          = "-DENABLE_EXPERIMENTAL_FEATURES=ON,-DENABLE_EXPERIMENTAL_FEATURES=OFF,"
+PACKAGECONFIG[fhd]                   = "-DVIDEO_DECODING_LIMIT=1920x1080@60,-DVIDEO_DECODING_LIMIT=3840x2160@60,"
+PACKAGECONFIG[gstreamergl]           = "-DUSE_GSTREAMER_GL=ON,-DUSE_GSTREAMER_GL=OFF,"
+PACKAGECONFIG[gstwebrtc]             = "-DUSE_GSTREAMER_WEBRTC=ON,-DUSE_GSTREAMER_WEBRTC=OFF, "
+PACKAGECONFIG[introspection]         = "-DENABLE_INTROSPECTION=ON,-DENABLE_INTROSPECTION=OFF, gobject-introspection-native"
+PACKAGECONFIG[journaldlog]           = "-DENABLE_JOURNALD_LOG=ON,-DENABLE_JOURNALD_LOG=OFF,"
+PACKAGECONFIG[jpegxl]                = "-DUSE_JPEGXL=ON,-DUSE_JPEGXL=OFF,"
+PACKAGECONFIG[lcms]                  = "-DUSE_LCMS=ON,-DUSE_LCMS=OFF, "
+PACKAGECONFIG[logs]                  = "-DENABLE_LOGS=ON,,"
+PACKAGECONFIG[malloc_heap_breakdown] = "-DENABLE_MALLOC_HEAP_BREAKDOWN=ON,-DENABLE_MALLOC_HEAP_BREAKDOWN=OFF,malloc-zone, malloc-zone"
+PACKAGECONFIG[mathml]                = "-DENABLE_MATHML=ON,-DENABLE_MATHML=OFF,"
+PACKAGECONFIG[mediarecoder]          = "-DENABLE_MEDIA_RECORDER=ON,-DENABLE_MEDIA_RECORDER=OFF,"
+PACKAGECONFIG[mediastream]           = "-DENABLE_MEDIA_STREAM=ON -DENABLE_WEB_RTC=ON,-DENABLE_MEDIA_STREAM=OFF -DENABLE_WEB_RTC=OFF,libevent libopus libvpx alsa-lib,libevent"
+PACKAGECONFIG[native_audio]          = "-DUSE_GSTREAMER_NATIVE_AUDIO=ON, -DUSE_GSTREAMER_NATIVE_AUDIO=OFF,"
+PACKAGECONFIG[native_video]          = "-DUSE_GSTREAMER_NATIVE_VIDEO=ON, -DUSE_GSTREAMER_NATIVE_VIDEO=OFF,"
+PACKAGECONFIG[pdfjs]                 = "-DENABLE_PDFJS=ON,-DENABLE_PDFJS=OFF,,"
+PACKAGECONFIG[releaselog]            = "-DENABLE_RELEASE_LOG=ON,"
+PACKAGECONFIG[remoteinspector]       = "-DENABLE_REMOTE_INSPECTOR=ON,-DENABLE_REMOTE_INSPECTOR=OFF,"
+PACKAGECONFIG[speechsynthesis]       = "-DENABLE_SPEECH_SYNTHESIS=ON -DUSE_FLITE=OFF -DUSE_TTS_CLIENT=ON,-DENABLE_SPEECH_SYNTHESIS=OFF,tts"
+PACKAGECONFIG[touchevents]           = "-DENABLE_TOUCH_EVENTS=ON,-DENABLE_TOUCH_EVENTS=OFF,"
+PACKAGECONFIG[video]                 = "-DENABLE_VIDEO=ON,-DENABLE_VIDEO=OFF,gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad,${RDEPS_VIDEO}"
+PACKAGECONFIG[webassembly]           = "-DENABLE_WEBASSEMBLY=ON,-DENABLE_WEBASSEMBLY=OFF, "
+PACKAGECONFIG[webdriver]             = "-DENABLE_WEBDRIVER=ON,-DENABLE_WEBDRIVER=OFF,"
+PACKAGECONFIG[woff2]                 = "-DUSE_WOFF2=ON,-DUSE_WOFF2=OFF,woff2"
+PACKAGECONFIG[wpeframework_opencdm]  = "-DENABLE_THUNDER=ON,-DENABLE_THUNDER=OFF,wpeframework-clientlibraries,"
+PACKAGECONFIG[wpeplatform]           = "-DENABLE_WPE_PLATFORM=ON,-DENABLE_WPE_PLATFORM=OFF -DUSE_LIBDRM=OFF -DUSE_GBM=OFF,libdrm,"
+PACKAGECONFIG[wpeqtapi]              = "-DENABLE_WPE_QT_API=ON,-DENABLE_WPE_QT_API=OFF"
+PACKAGECONFIG[cairo]                 = "-DUSE_CAIRO=ON -DUSE_SKIA=OFF,-DUSE_CAIRO=OFF,cairo"
+PACKAGECONFIG[externalholepunch]     = "-DUSE_EXTERNAL_HOLEPUNCH=ON,-DUSE_EXTERNAL_HOLEPUNCH=OFF,"
+PACKAGECONFIG[ftrace]                = "-DUSE_LINUX_FTRACE=ON,-DUSE_LINUX_FTRACE=OFF,"
+
+# Config options are no longer available in 2.46
+PACKAGECONFIG[2dcanvas]     = ""
+PACKAGECONFIG[indexeddb]    = ""
+PACKAGECONFIG[subtlecrypto] = ""
+PACKAGECONFIG[westeros]     = ""
+
+PACKAGECONFIG:append = " webdriver remoteinspector releaselog accessibility speechsynthesis native_video webaudio woff2 externalholepunch"
+PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'malloc_heap_breakdown', 'malloc_heap_breakdown', '', d)}"
+PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'wpe-webkit-developer-mode', 'developermode tools', '', d)}"
+PACKAGECONFIG:append = " ${@bb.utils.contains('BROWSER_MEMORYPROFILE', 'fhd', 'fhd', '', d)}"
+
+PACKAGECONFIG:append:aarch64 = " webassembly"
+PACKAGECONFIG:append:toolchain-clang = " uselld"
+
+EXTRA_OECMAKE += " \
+  -DPYTHON_EXECUTABLE=${STAGING_BINDIR_NATIVE}/python3-native/python3 \
+  -DGL_TEXTURE_MAX_SIZE=2000 \
+  -DWPE_VERSION_MICRO_SUFFIX=${WPE_MICRO_VERSION_SUFFIX} \
+"
+
+FILES:${PN} += " ${libdir}/wpe-webkit-*/injected-bundle/libWPEInjectedBundle.so"
+FILES:${PN}-web-inspector-plugin += " ${libdir}/wpe-webkit-*/libWPEWebInspectorResources.so"
+
+TUNE_CCARGS:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'wpe-webkit-debugfission', '','-fno-omit-frame-pointer -fno-optimize-sibling-calls', d)}"
+TUNE_CCARGS:append = " -fno-delete-null-pointer-checks"
+
+WPE_WEBKIT_LTO ??= "-flto=auto"
+TARGET_CFLAGS += "${WPE_WEBKIT_LTO}"
+TARGET_LDFLAGS += "${WPE_WEBKIT_LTO}"
+TARGET_LDFLAGS:toolchain-clang += "-fuse-ld=lld"
+
+def wk_use_ccache(bb,d):
+    if d.getVar('CCACHE_DISABLED', True) == "1":
+       return "NO"
+    if bb.data.inherits_class("icecc", d) and d.getVar('ICECC_DISABLED', True) != "1":
+       return "NO"
+    return "YES"
+export WK_USE_CCACHE="${@wk_use_ccache(bb, d)}"
+
+python () {
+    suffix = d.getVar('WPE_MICRO_VERSION_SUFFIX')
+    if not suffix.isdigit() or len(suffix) != 4:
+        bb.fatal('WPE_MICRO_VERSION_SUFFIX must be exactly 4 digits, got "%s"' % suffix)
+}


### PR DESCRIPTION
Bring the latest tip of downstream WPEWebKit repository
 - Added support for AC-4 codec
 - Reworked GST registry scanner mp4a* codecs support
 - Detect Rialto OCDM impl
 - Disable GPU memory calculations for service workers
 - WebKit micro version suffix