### PR TITLE
RDKEMW-16133: tts: split bolt and mw configurations for firebolt support

### DIFF
--- a/recipes-graphics/tts/tts-bolt.inc
+++ b/recipes-graphics/tts/tts-bolt.inc
@@ -1,0 +1,9 @@
+DEPENDS += "firebolt-cpp-client"
+
+EXTRA_OECMAKE += "-DTTS_DEFAULT_BACKEND=firebolt"
+EXTRA_OECMAKE += "-DENABLE_FIREBOLT_ONLY=ON"
+
+CXXFLAGS += " -I${STAGING_INCDIR}/firebolt -I${STAGING_INCDIR}/glib-2.0 -I${STAGING_INCDIR}/../usr/lib/glib-2.0/include "
+CXXFLAGS += " -std=gnu++17"
+EXTRA_OECMAKE:remove = " -std=gnu++11"
+CXXFLAGS:remove = " -std=gnu++11"

--- a/recipes-graphics/tts/tts-mw.inc
+++ b/recipes-graphics/tts/tts-mw.inc
@@ -1,0 +1,6 @@
+DEPENDS += "rdk-logger wpeframework wpeframework-clientlibraries firebolt-cpp-client"
+
+CXXFLAGS += " -I${STAGING_INCDIR}/firebolt -I${STAGING_INCDIR}/glib-2.0 -I${STAGING_INCDIR}/../usr/lib/glib-2.0/include "
+CXXFLAGS += " -std=gnu++17"
+EXTRA_OECMAKE:remove = " -std=gnu++11"
+CXXFLAGS:remove = " -std=gnu++11"

--- a/recipes-graphics/tts/tts.bb
+++ b/recipes-graphics/tts/tts.bb
@@ -5,9 +5,11 @@ voices it out through gstreamer"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${THISDIR}/files/Apache-2.0;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-DEPENDS += "gstreamer1.0-plugins-base rdk-logger wpeframework wpeframework-clientlibraries"
+DEPENDS += "gstreamer1.0-plugins-base"
 
-SRCREV = "0845f4da2b886e6cc707077c8f290cc279a84e11"
+require ${@'tts-bolt.inc' if d.getVar('DISTRO') == 'bolt-distro' else 'tts-mw.inc'}
+
+SRCREV = "${AUTOREV}"
 
 PV = "1.0.5"
 PR = "r0"
@@ -18,14 +20,10 @@ DEPENDS += "breakpad breakpad-wrapper"
 EXTRA_OECMAKE += "-DENABLE_BREAKPAD=1"
 BREAKPAD_BIN = " TTSEngine *.so "
 
-SRC_URI = "${CMF_GITHUB_ROOT}/ttsengine;${CMF_GITHUB_SRC_URI_SUFFIX}"
+SRC_URI = "git://github.com/lulicdarko/ttsengine.git;protocol=https;branch=tts_against_firebolt_0.5.3 \
+    "
 
 S = "${WORKDIR}/git"
-
-CXXFLAGS += " -I${STAGING_INCDIR}/Firebolt -I${STAGING_INCDIR}/glib-2.0 -I${STAGING_INCDIR}/../usr/lib/glib-2.0/include "
-CXXFLAGS += " -std=gnu++17"
-EXTRA_OECMAKE:remove = " -std=gnu++11"
-CXXFLAGS:remove = " -std=gnu++11"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 DISTRO_FEATURES_CHECK = "wpe_r4_4 wpe_r4"


### PR DESCRIPTION
Reason for change: Separate build configurations for middleware and firebolt backends. tts-bolt.inc uses firebolt backend with ENABLE_FIREBOLT_ONLY; tts-mw.inc uses wpeframework backend with rdk-logger. tts.bb conditionally requires one or the other based on DISTRO.

Test Procedure: Build wpe-webkit with bolt-distro DISTRO and verify TTS uses firebolt backend. Build with rdk-mw DISTRO and verify TTS uses wpeframework backend.