### PR TITLE
RDKEMW-18392: getFirmwareDownloadPercent api is failed During CDL Migration testing

### DIFF
--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
           "
 
 # Release version - 3.1.19.2
-SRCREV = "8b4c48385a79b537c1901feff2cef0c61c7607e7"
+SRCREV = "41fc779df11e787d2bb5651cf35fd1f3f482512f"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
           "
 
 # Release version - 3.1.19.2
-SRCREV = "7214ab483fc88dad0eb5fd32a1587ce0dbe20589"
+SRCREV = "8b4c48385a79b537c1901feff2cef0c61c7607e7"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-extended/entservices/entservices-deviceanddisplay.bb
+++ b/recipes-extended/entservices/entservices-deviceanddisplay.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices deviceanddisplay plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dc6e390ad71aef79d0c2caf3cde03a19"
 
-PV ?= "3.1.19.2"
+PV ?= "3.1.19.3"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"
@@ -12,8 +12,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-deviceanddisplay;${CMF_GITHUB_SRC_URI_
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
 
-# Release version - 3.1.19.2
-SRCREV = "41fc779df11e787d2bb5651cf35fd1f3f482512f"
+# Release version - 3.1.19.3
+SRCREV = "2113263d6b39781e55372e05f554556626ea2191"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: fixed the getFirmwareDownloadPercent api is failed During CDL Migration testing
Test Procedure: Test getFirmwareDownloadPercent API
Risks: Medium
Priority: P1
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]