### PR TITLE
RDKEMW-18373, RDKEMW-18149, RDKEMW-16719, RDKEMW-16318: Fix by incrementing _refCount before releasing _channel …

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/fixunkownproxyrelease.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/fixunkownproxyrelease.patch
@@ -1,0 +1,151 @@
+diff --git a/Source/com/Administrator.cpp b/Source/com/Administrator.cpp
+index 6de35743..56f0fca0 100644
+--- a/Source/com/Administrator.cpp
++++ b/Source/com/Administrator.cpp
+@@ -105,13 +105,13 @@ namespace RPC {
+         proxy->Complete(response);
+     }
+ 
+-    bool Administrator::UnregisterUnknownProxy(const ProxyStub::UnknownProxy& proxy)
++    bool Administrator::UnregisterUnknownProxy(const ProxyStub::UnknownProxy& proxy, uintptr_t channelId)
+     {
+         bool removed = false;
+ 
+         _adminLock.Lock();
+ 
+-        ChannelMap::iterator index(_channelProxyMap.find(proxy.LinkId()));
++        ChannelMap::iterator index(_channelProxyMap.find(channelId));
+ 
+         if (index != _channelProxyMap.end()) {
+             Proxies::iterator entry(index->second.begin());
+@@ -124,20 +124,17 @@ namespace RPC {
+                 if (index->second.size() == 0) {
+                     _channelProxyMap.erase(index);
+                 }
+-                else {
+-                    // If it is not found, check the dangling map
+-                    Proxies::iterator index = std::find(_danglingProxies.begin(), _danglingProxies.end(), &proxy);
+-
+-                    if (index != _danglingProxies.end()) {
+-                        _danglingProxies.erase(index);
+-                    }
+-                    else {
+-                        TRACE_L1("Could not find the Proxy entry to be unregistered from a channel perspective.");
+-		    }
+-		}
+             }
+         } else {
+-            TRACE_L1("Could not find the Proxy entry to be unregistered from a channel perspective.");
++            // Channel has already been deleted (channelId == 0 or DeleteChannel already ran);
++            // search the dangling list for the proxy by pointer.
++            Proxies::iterator dangling = std::find(_danglingProxies.begin(), _danglingProxies.end(), &proxy);
++            if (dangling != _danglingProxies.end()) {
++                _danglingProxies.erase(dangling);
++                removed = true;
++            } else {
++                TRACE_L1("Could not find the Proxy entry to be unregistered from a channel perspective.");
++            }
+         }
+ 
+         _adminLock.Unlock();
+diff --git a/Source/com/Administrator.h b/Source/com/Administrator.h
+index d74cf044..5e9a488c 100644
+--- a/Source/com/Administrator.h
++++ b/Source/com/Administrator.h
+@@ -292,7 +292,7 @@ namespace RPC {
+ 
+             _adminLock.Unlock();
+         }
+-        bool UnregisterUnknownProxy(const ProxyStub::UnknownProxy& proxy);
++        bool UnregisterUnknownProxy(const ProxyStub::UnknownProxy& proxy, uintptr_t channelId);
+ 
+    private:
+         // ----------------------------------------------------------------------------------------------------
+diff --git a/Source/com/IUnknown.h b/Source/com/IUnknown.h
+index e6749f87..44c51c33 100644
+--- a/Source/com/IUnknown.h
++++ b/Source/com/IUnknown.h
+@@ -160,6 +160,8 @@ namespace ProxyStub {
+             ASSERT(_refCount > 0);
+             _adminLock.Lock();
+             if (_channel.IsValid() == true) {
++                _refCount++;    // Take a reference on behalf of the _danglingProxies entry so the proxy is not
++                                // destroyed while still tracked; balanced by UnregisterUnknownProxy() -> Release().
+                 _channel.Release();
+                 succeeded = true;
+             }
+@@ -209,42 +211,51 @@ namespace ProxyStub {
+  
+             if (_refCount > 1 ) {  // note this proxy is also held in the administrator list for non happy day scenario's so we should already release with refcount one, the UnregisterProxy will remove it from the list
+                 _adminLock.Unlock();
+-            } 
+-            else if( _refCount == 0 ) {
+-                _adminLock.Unlock();
+-                result = Core::ERROR_DESTRUCTION_SUCCEEDED;
+-                ASSERT(_channel.IsValid() == false);
++                if (_channel.IsValid() == false) {
++                    // Channel is gone (Invalidate() was called) but other references still exist.
++                    // Signal the caller so it does not interpret ERROR_NONE as a live connection.
++                    result = Core::ERROR_CONNECTION_CLOSED;
++                }
+             }
+             else {
+-                if ((_channel.IsValid() == true) && ((_mode & (CACHING_RELEASE|CACHING_ADDREF)) == 0)) {
++                ASSERT(_refCount == 1);
++                uintptr_t channelId = 0;
+ 
+-                    // We have reached "0", signal the other side..
+-                    Core::ProxyType<RPC::InvokeMessage> message(RPC::Administrator::Instance().Message());
++                if (_channel.IsValid() == true) {
++                    if ((_mode & (CACHING_RELEASE|CACHING_ADDREF)) == 0) {
+ 
+-                    message->Parameters().Set(_implementation, _interfaceId, 1);
++                        // We have reached "0", signal the other side..
++                        Core::ProxyType<RPC::InvokeMessage> message(RPC::Administrator::Instance().Message());
+ 
+-                    // Pass on the number of reference we need to lower, since it is indicated by the amount of times this proxy had to be created
+-                    message->Parameters().Writer().Number<uint32_t>(_remoteReferences);
++                        message->Parameters().Set(_implementation, _interfaceId, 1);
+ 
+-                    // Just try the destruction for few Seconds...
+-                    result = _channel->Invoke(message, RPC::CommunicationTimeOut);
++                        // Pass on the number of reference we need to lower, since it is indicated by the amount of times this proxy had to be created
++                        message->Parameters().Writer().Number<uint32_t>(_remoteReferences);
+ 
+-                    if (result != Core::ERROR_NONE) {
+-                        TRACE_L1("Could not remote release the Proxy.");
+-                        result |= COM_ERROR;
+-                    }
+-                    else {
+-                        // Pass the remote release return value through
+-                        result = message->Response().Reader().Number<uint32_t>();
++                        // Just try the destruction for few Seconds...
++                        result = _channel->Invoke(message, RPC::CommunicationTimeOut);
++
++                        if (result != Core::ERROR_NONE) {
++                            TRACE_L1("Could not remote release the Proxy.");
++                            result |= COM_ERROR;
++                        }
++                        else {
++                            // Pass the remote release return value through
++                            result = message->Response().Reader().Number<uint32_t>();
++                        }
+                     }
++
++                    // Capture channelId before releasing _channel so UnregisterUnknownProxy can locate
++                    // this proxy in _channelProxyMap or _danglingProxies regardless of race with
++                    // DeleteChannel / Invalidate().
++                    channelId = _channel->LinkId();
++                    _channel.Release();
+                 }
+ 
+                 _adminLock.Unlock();
+ 
+                 // Remove our selves from the Administration, we are done..
+-                if (RPC::Administrator::Instance().UnregisterUnknownProxy(*this) == true ) {
+-                    ASSERT(_refCount == 1);
+-                    _refCount = 0;
++                if (RPC::Administrator::Instance().UnregisterUnknownProxy(*this, channelId) == true) {
+                     result = Core::ERROR_DESTRUCTION_SUCCEEDED;
+                 }
+             }

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -75,6 +75,7 @@ SRC_URI += "file://r4.4/PR-1369-Wait-for-Open-in-Communication-Channel.patch \
             file://r4.4/EnablePISLogging.patch \
             file://r4.4/0001-LIMIT-Limit-handing-out-interfaces-of-Plugins-only-i.patch \
             file://r4.4/StartCOMServerAfterControllerInit.patch \
+            file://r4.4/fixunkownproxyrelease.patch \
            "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change: Updating the patch to fix use-after-free SIGSEGV in UnknownProxy Release/Invalidate 
Risks: Low
Priority: P1
Signed-off-by: Satheeshkumar G satheeshkumar_g@comcast.com