### PR TITLE
RDKEMW-18520: Fix: Removed calling mWsManager.Close() on already-disconnected socket

### DIFF
--- a/recipes-extended/entservices/entservices-appgateway.bb
+++ b/recipes-extended/entservices/entservices-appgateway.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=9adde9d5cb6e9c095d3e3abf0e9500f1"
 
 PV = "1.0.3.5"
 PR = "r0"
-SRCREV = "8f6ef0b30640634dc6f493c2ee535bc585825b5d"
+SRCREV = "da3600ba3e0c20847a5bd564cff6c7c856f8c297"
 
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig


### PR DESCRIPTION
Refer the JIRA ticket RDKEMW-17793 for the original bug report.