### PR TITLE
RDKEMW-18043: Release Cryptography Vault singleton SecProcessor handle on deep sleep

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch
@@ -1,0 +1,33 @@
+RDKEMW-18043: Add vault_processor_release() C wrapper to release the
+Cryptography Vault singleton's SecProcessor handle before deep-sleep entry.
+
+The default Implementation::Vault is a process-lifetime singleton (static
+local in vault_instance()); its destructor never runs at deep sleep, so the
+SA2 SecProcessor handle stays open across S3.  On BCM Dhruv with Network
+Standby OFF this triggers SOFTWARE_MASTER_RESET because SAGE refuses S3
+entry while the handle is held.
+
+Implementation::Vault::ProcessorRelease() already exists (paired with
+ProcessorAcquire() added by 0001-SecAPI-Re-acquire-sec-handle-after-flush.patch).
+This wrapper exposes it via C ABI so the CryptographyExtAccess plugin can
+call it from onPowerModeChanged.  Re-acquire on wake is automatic via the
+existing factory.
+
+Index: git/Source/cryptography/implementation/SecApi/Vault.cpp
+===================================================================
+--- git.orig/Source/cryptography/implementation/SecApi/Vault.cpp
++++ git/Source/cryptography/implementation/SecApi/Vault.cpp
+@@ -748,5 +748,13 @@ extern "C" {
+             return (Thunder::Core::ERROR_UNAVAILABLE);
+         }
+ 
+     }
++
++    void vault_processor_release(void)
++    {
++        VaultImplementation* impl = vault_instance(CRYPTOGRAPHY_VAULT_DEFAULT);
++        if (impl != nullptr) {
++            reinterpret_cast<Implementation::Vault*>(impl)->ProcessorRelease();
++        }
++    }
+ } // extern "C"

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
@@ -28,6 +28,7 @@ SRC_URI = "git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=https
            file://0001-error-handling-if-invalid-external-input.patch \
            file://r4.4/0001-Implement-IPersistent-interface-for-RPC-Vault.patch \
            file://r4.4/0001-SecAPI-Re-acquire-sec-handle-after-flush.patch \
+           file://r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch \
            file://r4.4/0001-DELIA-64727-Prealloc-secure-memory-before-decrypt.patch \
            file://r4.4/0001-RDKEMW-7064-Dont-decrypt-fake-buffer-is-revoke-has-b.patch \
            file://r4.4/0001-PowerManagerClient-library-implementation.patch \


### PR DESCRIPTION
Full rationale, validation, paired changes, and risk notes are in the lead commit message.

JIRA: https://jira.rdkcentral.com/jira/browse/RDKEMW-18043
