### PR TITLE
RDKMVE-2287 : Widevine DRM version upgraded to 18 [RDK9]

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework-ocdm-widevine_git.bb
+++ b/recipes-extended/wpe-framework/wpeframework-ocdm-widevine_git.bb
@@ -5,11 +5,11 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=19a2b3c39737289f92c7991b16599360"
 include recipes-extended/wpe-framework/include/wpeframework-plugins.inc
 
 PR = "r0"
-PV = "1.0.2"
+PV = "1.1.0"
 
 SRC_URI = "git://github.com/rdkcentral/widevine-rdk.git;${CMF_GITHUB_SRC_URI_SUFFIX}"
-# TAG version 1.0.2
-SRCREV = "2aa9f3adf9bc24e924e4ab1ee415e7eacee227c4"
+# TAG version 1.1.0
+SRCREV = "731e7c5908b512f5cc891805cc30e671b7ad0d7c"
 
 # Platform configurations
 DEPENDS += " ${platform-widevine-depends}"


### PR DESCRIPTION
Reason for change: updating widevine drm verison to 18

Test Procedure: Build and verify.

Signed-off-by: ligin_punoose@comcast.com