### PR TITLE
RDKEMW-19048: META_PATCHSET bundle (bbappend + entservices-cryptography SRCREV) for develop custom build

### DIFF
--- a/recipes-extended/entservices/entservices-cryptography.bb
+++ b/recipes-extended/entservices/entservices-cryptography.bb
@@ -16,8 +16,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-cryptography;${CMF_GITHUB_SRC_URI_SUFF
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
           
-# Release version - 1.0.2
-SRCREV = "4c84cc95a443c4c5d9b704631688c741d6fb07e1"
+# RDKEMW-19048: pinned to entservices-cryptography PR #10 head
+SRCREV = "db7b7d96a3d00fcf65413b76988207e6f1fa870e"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch
@@ -1,0 +1,33 @@
+RDKEMW-18043: Add vault_processor_release() C wrapper to release the
+Cryptography Vault singleton's SecProcessor handle before deep-sleep entry.
+
+The default Implementation::Vault is a process-lifetime singleton (static
+local in vault_instance()); its destructor never runs at deep sleep, so the
+SA2 SecProcessor handle stays open across S3.  On BCM Dhruv with Network
+Standby OFF this triggers SOFTWARE_MASTER_RESET because SAGE refuses S3
+entry while the handle is held.
+
+Implementation::Vault::ProcessorRelease() already exists (paired with
+ProcessorAcquire() added by 0001-SecAPI-Re-acquire-sec-handle-after-flush.patch).
+This wrapper exposes it via C ABI so the CryptographyExtAccess plugin can
+call it from onPowerModeChanged.  Re-acquire on wake is automatic via the
+existing factory.
+
+Index: git/Source/cryptography/implementation/SecApi/Vault.cpp
+===================================================================
+--- git.orig/Source/cryptography/implementation/SecApi/Vault.cpp
++++ git/Source/cryptography/implementation/SecApi/Vault.cpp
+@@ -748,5 +748,13 @@ extern "C" {
+             return (Thunder::Core::ERROR_UNAVAILABLE);
+         }
+ 
+     }
++
++    void vault_processor_release(void)
++    {
++        VaultImplementation* impl = vault_instance(CRYPTOGRAPHY_VAULT_DEFAULT);
++        if (impl != nullptr) {
++            reinterpret_cast<Implementation::Vault*>(impl)->ProcessorRelease();
++        }
++    }
+ } // extern "C"

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
@@ -28,6 +28,7 @@ SRC_URI = "git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=https
            file://0001-error-handling-if-invalid-external-input.patch \
            file://r4.4/0001-Implement-IPersistent-interface-for-RPC-Vault.patch \
            file://r4.4/0001-SecAPI-Re-acquire-sec-handle-after-flush.patch \
+           file://r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch \
            file://r4.4/0001-DELIA-64727-Prealloc-secure-memory-before-decrypt.patch \
            file://r4.4/0001-RDKEMW-7064-Dont-decrypt-fake-buffer-is-revoke-has-b.patch \
            file://r4.4/0001-PowerManagerClient-library-implementation.patch \


### PR DESCRIPTION
## Summary

Ad-hoc META_PATCHSET branch for the [RDKEMW-19048](https://jira.rdkcentral.com/jira/browse/RDKEMW-19048) develop custom build.

Stacked on top of [#4172](https://github.com/rdkcentral/meta-rdk-video/pull/4172). Adds one extra commit pinning `entservices-cryptography.bb` SRCREV to [entservices-cryptography #10](https://github.com/rdkcentral/entservices-cryptography/pull/10) head (`db7b7d96`).

Build-input PR only - **not for merge as-is**. RM should redo the SRCREV bump cleanly off the entservices-cryptography tag once #10 merges. The real submission is #4172 (bbappend patch only).

This PR exists so the develop MW build's `META_PATCHSET` can point at a single SHA (`8bc2c7a7`) that carries both the bbappend patch and the SRCREV bump.

## Test plan

- [ ] Develop META_PATCHSET source for the Sky Llama (AMLOGIC) regression build