### PR TITLE
RDKEMW-15246 : Consume Apparmor release

### DIFF
--- a/recipes-mac/apparmor/apparmor-generic.bb
+++ b/recipes-mac/apparmor/apparmor-generic.bb
@@ -2,12 +2,12 @@ DESCRIPTION = "Apparmor generic profiles RDK"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://rdk-apparmor-profiles/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-PV = "2.4.0"
+PV = "2.4.1"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 inherit pkgconfig autotools systemd
-SRCREV_rdk-apparmor-profiles = "772b7090262672edf6c66f801cb7ec9ce8796519"
+SRCREV_rdk-apparmor-profiles = "1486b2e08e26b540bf7be71b1b6bcf1697c3d329"
 SRC_URI = "${CMF_GITHUB_ROOT}/rdk-apparmor-profiles.git;${CMF_GITHUB_SRC_URI_SUFFIX};destsuffix=git/rdk-apparmor-profiles;name=rdk-apparmor-profiles"
 
 S = "${WORKDIR}/git"

--- a/recipes-mac/apparmor/apparmor-generic.bb
+++ b/recipes-mac/apparmor/apparmor-generic.bb
@@ -7,7 +7,7 @@ PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 inherit pkgconfig autotools systemd
-SRCREV_rdk-apparmor-profiles = "e7ee210e8c36080446f72c9355403591ad229935"
+SRCREV_rdk-apparmor-profiles = "772b7090262672edf6c66f801cb7ec9ce8796519"
 SRC_URI = "${CMF_GITHUB_ROOT}/rdk-apparmor-profiles.git;${CMF_GITHUB_SRC_URI_SUFFIX};destsuffix=git/rdk-apparmor-profiles;name=rdk-apparmor-profiles"
 
 S = "${WORKDIR}/git"

--- a/recipes-mac/apparmor/apparmor-generic.bb
+++ b/recipes-mac/apparmor/apparmor-generic.bb
@@ -7,7 +7,7 @@ PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 inherit pkgconfig autotools systemd
-SRCREV_rdk-apparmor-profiles = "d44bb823cbf4bb4fcd2460f0810ef18131869183"
+SRCREV_rdk-apparmor-profiles = "e7ee210e8c36080446f72c9355403591ad229935"
 SRC_URI = "${CMF_GITHUB_ROOT}/rdk-apparmor-profiles.git;${CMF_GITHUB_SRC_URI_SUFFIX};destsuffix=git/rdk-apparmor-profiles;name=rdk-apparmor-profiles"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This PR adds the Chrony Control Library (in-house RDK library) to the systemtimemgr AppArmor profile.
To add the necessary permissions for chrony control operations used by systemtimemgr