### PR TITLE
RDKEMW-15726 : Migrate COM-RPC support for ResourceManager to standalone repository

### DIFF
--- a/recipes-extended/entservices/entservices-resourcemanager.bb
+++ b/recipes-extended/entservices/entservices-resourcemanager.bb
@@ -8,7 +8,7 @@ PR = "r0"
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
-SRCREV = "${PV}"
+SRCREV = "971e1e5fe6c5e831a3859543af74672e6cf8b02f"
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-resourcemanager;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://rdkservices.ini \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \


### PR DESCRIPTION
Reason For Change: Changing meta layer
Test procedure : check Ticket
Priority: P2