### PR TITLE
RDKEMW-19331: Add proper NULL check before accessing service object in HdmiCecSink plugin

### DIFF
--- a/recipes-extended/entservices/entservices-hdmicecsink.bb
+++ b/recipes-extended/entservices/entservices-hdmicecsink.bb
@@ -2,7 +2,7 @@ SUMMARY = "ENTServices hdmicecsink plugin"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-PV = "1.2.0"
+PV = "1.4.3"
 PR = "r0"
 
 S = "${WORKDIR}/git"
@@ -13,8 +13,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-hdmicecsink;${CMF_GITHUB_SRC_URI_SUFFI
            file://rdkservices.ini \
           "
 
-# Release version - 1.2.0
-SRCREV = "a75cffe56e0f2eef20cd635f75d9e06ba69c7018"
+# Release version - 1.4.3
+SRCREV = "0079dea53099439271568f762d41a5ff1bb51835"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
RDKEMW-19331: Add proper NULL check before accessing service object in HdmiCecSink plugin

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]