### PR TITLE
RDKEMW-16055: Replace the System API calls from Json RPC to COM-RPC

### DIFF
--- a/recipes-extended/entservices/entservices-infra.bb
+++ b/recipes-extended/entservices/entservices-infra.bb
@@ -8,7 +8,7 @@ PR = "r0"
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
-SRCREV = "${PV}"
+SRCREV = "b1511d867cbf313a6c6394913084009931e6c097"
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-infra;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://rdkshell_post_startup.conf \
            file://rdkservices.ini \


### PR DESCRIPTION
Reason for change: Replaced the System API calls from Json RPC to COMRPC
Test Procedure: check the ticket
Risks: Medium
Priority: P1
version: Patch