### PR TITLE
RDKEMW-19048: meta-rdk-video build-input for develop custom build (iter -4)

### DIFF
--- a/recipes-extended/entservices/entservices-cryptography.bb
+++ b/recipes-extended/entservices/entservices-cryptography.bb
@@ -16,8 +16,8 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-cryptography;${CMF_GITHUB_SRC_URI_SUFF
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \
           "
           
-# Release version - 1.0.2
-SRCREV = "4c84cc95a443c4c5d9b704631688c741d6fb07e1"
+# RDKEMW-19048: pinned to entservices-cryptography PR #12 head
+SRCREV = "99619dceff69590f59d9e4e23aff9b0bee568a4c"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}" 
 TOOLCHAIN = "gcc"

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch
@@ -1,0 +1,33 @@
+RDKEMW-18043: Add vault_processor_release() C wrapper to release the
+Cryptography Vault singleton's SecProcessor handle before deep-sleep entry.
+
+The default Implementation::Vault is a process-lifetime singleton (static
+local in vault_instance()); its destructor never runs at deep sleep, so the
+SA2 SecProcessor handle stays open across S3.  On BCM Dhruv with Network
+Standby OFF this triggers SOFTWARE_MASTER_RESET because SAGE refuses S3
+entry while the handle is held.
+
+Implementation::Vault::ProcessorRelease() already exists (paired with
+ProcessorAcquire() added by 0001-SecAPI-Re-acquire-sec-handle-after-flush.patch).
+This wrapper exposes it via C ABI so the CryptographyExtAccess plugin can
+call it from onPowerModeChanged.  Re-acquire on wake is automatic via the
+existing factory.
+
+Index: git/Source/cryptography/implementation/SecApi/Vault.cpp
+===================================================================
+--- git.orig/Source/cryptography/implementation/SecApi/Vault.cpp
++++ git/Source/cryptography/implementation/SecApi/Vault.cpp
+@@ -748,5 +748,13 @@ extern "C" {
+             return (Thunder::Core::ERROR_UNAVAILABLE);
+         }
+ 
+     }
++
++    void vault_processor_release(void)
++    {
++        VaultImplementation* impl = vault_instance(CRYPTOGRAPHY_VAULT_DEFAULT);
++        if (impl != nullptr) {
++            reinterpret_cast<Implementation::Vault*>(impl)->ProcessorRelease();
++        }
++    }
+ } // extern "C"

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0003-RDKEMW-19048-Reacquire-SecProcessor-on-Vault-method-entry.patch
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0003-RDKEMW-19048-Reacquire-SecProcessor-on-Vault-method-entry.patch
@@ -15,24 +15,24 @@ Index: git/Source/cryptography/implementation/SecApi/Vault.h
      private:
 +        void EnsureProcessor() const;
          mutable WPEFramework::Core::CriticalSection _lock;
-         Sec_ProcessorHandle* _secProcHandle;
+-        Sec_ProcessorHandle* _secProcHandle;
++        mutable Sec_ProcessorHandle* _secProcHandle;
          std::map<uint32_t, MapStore> _items;
 Index: git/Source/cryptography/implementation/SecApi/Vault.cpp
 ===================================================================
 --- git.orig/Source/cryptography/implementation/SecApi/Vault.cpp
 +++ git/Source/cryptography/implementation/SecApi/Vault.cpp
-@@ -76,6 +76,18 @@ namespace Implementation {
+@@ -76,6 +76,17 @@ namespace Implementation {
  	     _lock.Unlock();
       }
 
 +    void Vault::EnsureProcessor() const
 +    {
 +        if (_secProcHandle == NULL) {
-+            Vault* self = const_cast<Vault*>(this);
-+            Sec_Result sec_res = SecProcessor_GetInstance_Directories(&self->_secProcHandle, globalDir, appDir);
++            Sec_Result sec_res = SecProcessor_GetInstance_Directories(&_secProcHandle, globalDir, appDir);
 +            if (sec_res != SEC_RESULT_SUCCESS) {
 +                TRACE_L1(_T("SEC : processor instance failed retval= %d\n"), sec_res);
-+                self->_secProcHandle = NULL;
++                _secProcHandle = NULL;
 +            }
 +        }
 +    }

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0003-RDKEMW-19048-Reacquire-SecProcessor-on-Vault-method-entry.patch
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries/r4.4/0003-RDKEMW-19048-Reacquire-SecProcessor-on-Vault-method-entry.patch
@@ -1,0 +1,114 @@
+RDKEMW-19048: reacquire SecProcessor at Vault method entry so callers
+that hold a cached VaultImplementation* (bypassing vault_instance) do
+not crash on _secProcHandle deref after ProcessorRelease.
+
+Upstream-Status: Pending
+Signed-off-by: Sergiy Gladkyy <sgladkyy@productengine.com>
+
+Index: git/Source/cryptography/implementation/SecApi/Vault.h
+===================================================================
+--- git.orig/Source/cryptography/implementation/SecApi/Vault.h
++++ git/Source/cryptography/implementation/SecApi/Vault.h
+@@ -122,6 +122,7 @@ namespace Implementation {
+ 	void ProcessorAcquire();
+
+     private:
++        void EnsureProcessor() const;
+         mutable WPEFramework::Core::CriticalSection _lock;
+         Sec_ProcessorHandle* _secProcHandle;
+         std::map<uint32_t, MapStore> _items;
+Index: git/Source/cryptography/implementation/SecApi/Vault.cpp
+===================================================================
+--- git.orig/Source/cryptography/implementation/SecApi/Vault.cpp
++++ git/Source/cryptography/implementation/SecApi/Vault.cpp
+@@ -76,6 +76,18 @@ namespace Implementation {
+ 	     _lock.Unlock();
+      }
+
++    void Vault::EnsureProcessor() const
++    {
++        if (_secProcHandle == NULL) {
++            Vault* self = const_cast<Vault*>(this);
++            Sec_Result sec_res = SecProcessor_GetInstance_Directories(&self->_secProcHandle, globalDir, appDir);
++            if (sec_res != SEC_RESULT_SUCCESS) {
++                TRACE_L1(_T("SEC : processor instance failed retval= %d\n"), sec_res);
++                self->_secProcHandle = NULL;
++            }
++        }
++    }
++
+     /*********************************************************************
+      * @function Size
+      *
+@@ -90,6 +103,7 @@ namespace Implementation {
+         uint16_t size = 0;
+
+         _lock.Lock();
++        EnsureProcessor();
+         auto it = _items.find(id);
+         if (it != _items.end()) {
+             if ((allowSealed == true) || (*it).second.IsExportable() == true) {
+@@ -140,6 +154,7 @@ namespace Implementation {
+         uint32_t id = 0;
+
+         _lock.Lock();
++        EnsureProcessor();
+             if (size > 0) {
+                 id = (_lastHandle + 1);
+                 if (id != 0) {
+@@ -225,6 +240,7 @@ namespace Implementation {
+         uint32_t id = 0;
+
+         _lock.Lock();
++        EnsureProcessor();
+         SEC_OBJECTID idcheck = 0x0;
+         struct IdStore ids;
+         string kFile(keyFile);
+@@ -286,6 +302,7 @@ namespace Implementation {
+         bool ret =false;
+
+         _lock.Lock();
++        EnsureProcessor();
+         SEC_OBJECTID idcheck = 0x0;
+         string kFile(keyFile);
+         string fileName = kFile.substr(0,SEC_ID_SIZE);
+@@ -329,6 +346,7 @@ namespace Implementation {
+         uint32_t id = 0;
+
+         _lock.Lock();
++        EnsureProcessor();
+         struct IdStore ids;
+         Sec_KeyType key = SEC_KEYTYPE_AES_128; //DEFAULT
+
+@@ -409,6 +427,7 @@ namespace Implementation {
+         uint16_t outSize = 0;
+         if (size > 0) {
+             _lock.Lock();
++            EnsureProcessor();
+             auto it = _items.find(id);
+             if (it != _items.end()) {
+                 if (((allowSealed == true) || (*it).second.IsExportable() == true) && ((*it).second.KeyLength() != 0)) {
+@@ -465,6 +484,7 @@ namespace Implementation {
+
+         if (size > 0) {
+             _lock.Lock();
++            EnsureProcessor();
+             id = (_lastHandle + 1);
+             if (id != 0) {
+                 SEC_BYTE store[SEC_KEYCONTAINER_MAX_LEN];
+@@ -506,6 +526,7 @@ namespace Implementation {
+
+         if (size > 0) {
+             _lock.Lock();
++            EnsureProcessor();
+             auto it = _items.find(id);
+             if (it != _items.end()) {
+                 SEC_BYTE* buff = const_cast<SEC_BYTE*>((*it).second.Buffer());
+@@ -548,6 +569,7 @@ namespace Implementation {
+         bool result = false;
+
+         _lock.Lock();
++        EnsureProcessor();
+         auto it = _items.find(id);
+         if (it != _items.end()) {
+             IdStore* ids = const_cast<IdStore*>((*it).second.getIdStore());

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
@@ -28,6 +28,7 @@ SRC_URI = "git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=https
            file://0001-error-handling-if-invalid-external-input.patch \
            file://r4.4/0001-Implement-IPersistent-interface-for-RPC-Vault.patch \
            file://r4.4/0001-SecAPI-Re-acquire-sec-handle-after-flush.patch \
+           file://r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch \
            file://r4.4/0001-DELIA-64727-Prealloc-secure-memory-before-decrypt.patch \
            file://r4.4/0001-RDKEMW-7064-Dont-decrypt-fake-buffer-is-revoke-has-b.patch \
            file://r4.4/0001-PowerManagerClient-library-implementation.patch \

--- a/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework-clientlibraries_4.4.bb
@@ -29,6 +29,7 @@ SRC_URI = "git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=https
            file://r4.4/0001-Implement-IPersistent-interface-for-RPC-Vault.patch \
            file://r4.4/0001-SecAPI-Re-acquire-sec-handle-after-flush.patch \
            file://r4.4/0002-RDKEMW-18043-Add-vault_processor_release-C-wrapper.patch \
+           file://r4.4/0003-RDKEMW-19048-Reacquire-SecProcessor-on-Vault-method-entry.patch \
            file://r4.4/0001-DELIA-64727-Prealloc-secure-memory-before-decrypt.patch \
            file://r4.4/0001-RDKEMW-7064-Dont-decrypt-fake-buffer-is-revoke-has-b.patch \
            file://r4.4/0001-PowerManagerClient-library-implementation.patch \


### PR DESCRIPTION
RDKEMW-19048

Per-iteration throwaway build-input PR for the AMLOGIC develop regression rebuild (`-4`).
Not for merge.

Carries:
- bbappend on `wpeframework-clientlibraries_4.4` adding the `vault_processor_release()` C wrapper patch (carrier for the open submission rdkcentral/meta-rdk-video PR #4172)
- bbappend on `wpeframework-clientlibraries_4.4` adding the `EnsureProcessor()` Vault method-entry reacquire patch with `mutable _secProcHandle` (carrier for the open submission rdkcentral/meta-rdk-video PR #4297)
- SRCREV bump for `entservices-cryptography` to PR #12 head `99619dceff69590f59d9e4e23aff9b0bee568a4c`

Supersedes iter `-2`'s #4210 (frozen as the historical reference for `-3`'s rebuild). Should be closed without merge once submissions #4172 / #4297 / entservices-cryptography #12 land and the SRCREV bump is redone cleanly off proper tags.