### PR TITLE
RDKEMW-19135: Fix proper cleanup service

### DIFF
--- a/recipes-extended/wpe-framework/wpeframework/r4.4/fix-proper-cleanup-service.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/fix-proper-cleanup-service.patch
@@ -1,5 +1,5 @@
 From 4fc97ba249e950eaef55210bfca5df58a50349a3 Mon Sep 17 00:00:00 2001
-From: SatheeshkumarG15 <satheeshkumar00150@gmail.com>
+From: Satheeshkumar G <satheeshkumar_g@comcast.com>
 Date: Fri, 5 Jun 2026 15:01:01 +0530
 Subject: [PATCH] Used an atomic bool and compare_exchange_strong to make sure
  either ResourceMonitor or Workerpool thread to properly clear out the service

--- a/recipes-extended/wpe-framework/wpeframework/r4.4/fix-proper-cleanup-service.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/fix-proper-cleanup-service.patch
@@ -1,11 +1,9 @@
 From 4fc97ba249e950eaef55210bfca5df58a50349a3 Mon Sep 17 00:00:00 2001
 From: Satheeshkumar G <satheeshkumar_g@comcast.com>
 Date: Fri, 5 Jun 2026 15:01:01 +0530
-Subject: [PATCH] Used an atomic bool and compare_exchange_strong to make sure
- either ResourceMonitor or Workerpool thread to properly clear out the service
- and to avoid the crash
+Subject: [PATCH] RDKEMW-19135: Fix service cleanup race between ResourceMonitor and WorkerPool
 
-Signed-off-by: SatheeshkumarG15 <satheeshkumar00150@gmail.com>
+Signed-off-by: Satheeshkumar G <satheeshkumar_g@comcast.com>
 ---
  Source/WPEFramework/PluginServer.cpp |  6 ++----
  Source/WPEFramework/PluginServer.h   | 19 ++++++++++++++-----

--- a/recipes-extended/wpe-framework/wpeframework/r4.4/fix-proper-cleanup-service.patch
+++ b/recipes-extended/wpe-framework/wpeframework/r4.4/fix-proper-cleanup-service.patch
@@ -1,0 +1,92 @@
+From 4fc97ba249e950eaef55210bfca5df58a50349a3 Mon Sep 17 00:00:00 2001
+From: SatheeshkumarG15 <satheeshkumar00150@gmail.com>
+Date: Fri, 5 Jun 2026 15:01:01 +0530
+Subject: [PATCH] Used an atomic bool and compare_exchange_strong to make sure
+ either ResourceMonitor or Workerpool thread to properly clear out the service
+ and to avoid the crash
+
+Signed-off-by: SatheeshkumarG15 <satheeshkumar00150@gmail.com>
+---
+ Source/WPEFramework/PluginServer.cpp |  6 ++----
+ Source/WPEFramework/PluginServer.h   | 19 ++++++++++++++-----
+ 2 files changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/Source/WPEFramework/PluginServer.cpp b/Source/WPEFramework/PluginServer.cpp
+index d04456e1..c31be7b9 100644
+--- a/Source/WPEFramework/PluginServer.cpp
++++ b/Source/WPEFramework/PluginServer.cpp
+@@ -949,6 +949,7 @@ namespace PluginHost
+         , _security(_parent.Officer())
+         , _service()
+         , _requestClose(false)
++        , _serviceCleanedUp(false)
+     {
+         TRACE(Activity, (_T("Construct a link with ID: [%d] to [%s]"), Id(), remoteId.QualifiedName().c_str()));
+     }
+@@ -958,11 +959,8 @@ namespace PluginHost
+         TRACE(Activity, (_T("Destruct a link with ID [%d] to [%s]"), Id(), RemoteId().c_str()));
+ 
+         // If we are still atatched to a service, detach, we are out of scope...
+-        if (_service.IsValid() == true) {
+-            _service->Unsubscribe(*this);
++        CleanupService();
+ 
+-            _service.Release();
+-        }
+         if (_security != nullptr) {
+             _security->Release();
+             _security = nullptr;
+diff --git a/Source/WPEFramework/PluginServer.h b/Source/WPEFramework/PluginServer.h
+index 51f7a5a3..63666fe5 100644
+--- a/Source/WPEFramework/PluginServer.h
++++ b/Source/WPEFramework/PluginServer.h
+@@ -26,6 +26,7 @@
+ #include "IRemoteInstantiation.h"
+ #include "WarningReportingCategories.h"
+ #include "PostMortem.h"
++#include <atomic>
+ 
+ #ifdef PROCESSCONTAINERS_ENABLED
+ #include "../processcontainers/ProcessContainer.h"
+@@ -4267,11 +4268,7 @@ POP_WARNING()
+ 
+                 // If we are closing (or closed) do the clean up
+                 if (IsOpen() == false) {
+-                    if (_service.IsValid() == true) {
+-                        _service->Unsubscribe(*this);
+-
+-                        _service.Release();
+-                    }
++                    CleanupService();
+ 
+                     State(CLOSED, false);
+                     _parent.Closed(Id());
+@@ -4323,6 +4320,17 @@ POP_WARNING()
+                 SetId(id);
+             }
+ 
++            void CleanupService()
++            {
++                bool expected = false;
++                if (_serviceCleanedUp.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
++                    if (_service.IsValid() == true) {
++                        _service->Unsubscribe(*this);
++                        _service.Release();
++                    }
++                }
++            }
++
+         private:
+             inline string SelectSupportedProtocol(const Web::ProtocolsArray& protocols)
+             {
+@@ -4353,6 +4361,7 @@ POP_WARNING()
+             PluginHost::ISecurity* _security;
+             Core::ProxyType<Service> _service;
+             bool _requestClose;
++            std::atomic<bool> _serviceCleanedUp;
+ 
+             // Factories for creating jobs that can be placed on the PluginHost Worker pool.
+             static Core::ProxyPoolType<WebRequestJob> _webJobs;
+-- 
+2.34.1
+

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -70,6 +70,8 @@ SRC_URI += "file://r4.4/PR-1369-Wait-for-Open-in-Communication-Channel.patch \
             file://r4.4/PR-2057-RDKEMW-14229_apply_sysinfo_mem_unit.patch \
             file://r4.4/0001-LIMIT-Limit-handing-out-interfaces-of-Plugins-only-i.patch \
             file://r4.4/StartCOMServerAfterControllerInit.patch \
+
+            file://r4.4/fix-proper-cleanup-service.patch \
            "
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/wpe-framework/wpeframework_4.4.bb
+++ b/recipes-extended/wpe-framework/wpeframework_4.4.bb
@@ -70,9 +70,10 @@ SRC_URI += "file://r4.4/PR-1369-Wait-for-Open-in-Communication-Channel.patch \
             file://r4.4/PR-2057-RDKEMW-14229_apply_sysinfo_mem_unit.patch \
             file://r4.4/0001-LIMIT-Limit-handing-out-interfaces-of-Plugins-only-i.patch \
             file://r4.4/StartCOMServerAfterControllerInit.patch \
-
-            file://r4.4/fix-proper-cleanup-service.patch \
            "
+
+SRC_URI += "file://r4.4/fix-proper-cleanup-service.patch \
+            "
 
 S = "${WORKDIR}/git"
 TOOLCHAIN = "gcc"


### PR DESCRIPTION
Reason for change: To avoid crash happening during cleanup of service in both ResourceMonitor and WorkerPool Threads
Risks: Low
Priority: P1
Signed-off-by: Satheeshkumar G satheeshkumar_g@comcast.com