### PR TITLE
RDKEMW-18671 : PROVIDED THE LAST DECRYPT STATUS VIA OCDM

### DIFF
--- a/recipes-extended/entservices/entservices-mediaanddrm.bb
+++ b/recipes-extended/entservices/entservices-mediaanddrm.bb
@@ -22,6 +22,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/entservices-mediaanddrm;${CMF_GITHUB_SRC_URI_SUFFI
            file://0001-Add-a-new-metrics-punch-through-on-the-OCDM-framework-rdkservice.patch \
            ${@bb.utils.contains('DISTRO_FEATURES', 'wpe_r4_4','file://0003-R4.4.1-SystemAudioPlayer-compilation-error.patch','',d)} \
            file://0001-set-OCDM-process-thread-name.patch \
+           file://001-DELIA-70580-get-last-decrypt-status_rdk.patch \
           "
           
 # Release version - 1.3.16

--- a/recipes-extended/entservices/files/001-DELIA-70580-get-last-decrypt-status_rdk.patch
+++ b/recipes-extended/entservices/files/001-DELIA-70580-get-last-decrypt-status_rdk.patch
@@ -1,0 +1,23 @@
+diff --git a/OpenCDMi/FrameworkRPC.cpp b/OpenCDMi/FrameworkRPC.cpp
+index f117b6f61..c2951adc9 100644
+--- a/OpenCDMi/FrameworkRPC.cpp
++++ b/OpenCDMi/FrameworkRPC.cpp
+@@ -365,9 +365,16 @@ namespace Plugin {
+                                     }
+                                 }
+ 
+-                                // Store the status we have for the other side.
++                                // Preserve the decrypt result used by the existing client-side return path.
+                                 Status(static_cast<uint32_t>(cr));
+ 
++                                // Publish the raw decrypt status reported by the DRM implementation when available.
++                                uint32_t lastDecryptStatus = static_cast<uint32_t>(cr);
++                                if (_mediaKeys->LastDecryptStatus(lastDecryptStatus) != CDMi::CDMi_SUCCESS) {
++                                    lastDecryptStatus = static_cast<uint32_t>(cr);
++                                }
++                                LastDecryptStatus(lastDecryptStatus);
++
+                                 // Whatever the result, we are done with the buffer..
+                                 Consumed();
+                             }
+


### PR DESCRIPTION
Reason for change: To address the technical fault issue, the last decrypt status was used as a workaround, as the key status notification from the CDM is delayed by approximately 6 seconds in RDK-V.
Test Procedure: Hot-plug HDMI cable and observe retry logic keep
Risks: Low