### PR TITLE
RDK-60913 : systemd service not found for org.rdk.ResourceManager plugin

### DIFF
--- a/recipes-extended/entservices/entservices-resourcemanager.bb
+++ b/recipes-extended/entservices/entservices-resourcemanager.bb
@@ -8,7 +8,7 @@ PR = "r0"
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
-SRCREV = "${PV}"
+SRCREV = "7787c5960d0304755fae26d288c22b13e6486b51"
 SRC_URI = "${CMF_GITHUB_ROOT}/entservices-resourcemanager;${CMF_GITHUB_SRC_URI_SUFFIX} \
            file://rdkservices.ini \
            file://0001-RDKTV-20749-Revert-Merge-pull-request-3336-from-npol.patch \


### PR DESCRIPTION
Reason For Change: updating meta layer
Test procedure : check Ticket
Priority: P2