### PR TITLE
RDKEMW-18919 : Remove product specific systimemgr config

### DIFF
--- a/recipes-common/systimemgr/systimemgr/systimemgr_ntp-dtt-drm-tee.conf
+++ b/recipes-common/systimemgr/systimemgr/systimemgr_ntp-dtt-drm-tee.conf
@@ -1,4 +1,0 @@
-timesrc  ntp /ntp
-timesrc dtt /dtt
-timesrc drm /drm
-timesync tee /tee

--- a/recipes-common/systimemgr/systimemgr_git.bbappend
+++ b/recipes-common/systimemgr/systimemgr_git.bbappend
@@ -2,8 +2,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 EXTRA_OECONF:append = "${@bb.utils.contains('DISTRO_FEATURES', 'tee_enabled', ' --enable-tee ', '', d)}"
 
-SRC_URI:append:ntp-dtt-drm-tee  = " file://systimemgr_ntp-dtt-drm-tee.conf "
-
 SRC_URI:append:ntp-dtt-rdkdefault = " file://systimemgr_ntp-dtt-rdkdefault.conf "
 
 CXXFLAGS += " -Wall -Werror"
@@ -13,9 +11,3 @@ do_install:append:ntp-dtt-rdkdefault() {
    install ${WORKDIR}/systimemgr_ntp-dtt-rdkdefault.conf ${D}${sysconfdir}/systimemgr.conf
 }
 
-do_install:append:ntp-dtt-drm-tee() {
-   install -d ${D}${sysconfdir}
-   install ${WORKDIR}/systimemgr_ntp-dtt-drm-tee.conf ${D}${sysconfdir}/systimemgr.conf
-   rm -f ${D}${systemd_unitdir}/system/systimemgr.service.d/secure.conf
-   find ${D}${systemd_unitdir}/system/systimemgr.service.d -type d -empty -delete
-}


### PR DESCRIPTION
Product specific systimemgr config should be removed from MW
This change installs the default systiemmgr config for all products.
IT specific config installation has been removed from here