### PR TITLE
RDKEMW-19899: Update rebootinfo when dsmgr,iarmbusd crash.

### DIFF
--- a/recipes-extended/iarmbus/iarmbus_git.bb
+++ b/recipes-extended/iarmbus/iarmbus_git.bb
@@ -9,7 +9,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 PV ?= "1.0.1"
-PR ?= "r1"
+PR ?= "r0"
 
 SRCREV_iarmbus ?= "fbfc891de8644f88cdd7e4a452c06b5a07e98ade"
 SRCREV_FORMAT = "iarmbus"

--- a/recipes-extended/iarmbus/iarmbus_git.bb
+++ b/recipes-extended/iarmbus/iarmbus_git.bb
@@ -9,9 +9,9 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 PV ?= "1.0.1"
-PR ?= "r2"
+PR ?= "r1"
 
-SRCREV_iarmbus ?= "98b2a4f2d9cfb2179705ab4fe7ee876a60965cbc"
+SRCREV_iarmbus ?= "fbfc891de8644f88cdd7e4a452c06b5a07e98ade"
 SRCREV_FORMAT = "iarmbus"
 SRC_URI = "${CMF_GITHUB_ROOT}/iarmbus;${CMF_GITHUB_SRC_URI_SUFFIX};name=iarmbus"
 

--- a/recipes-extended/iarmbus/iarmbus_git.bb
+++ b/recipes-extended/iarmbus/iarmbus_git.bb
@@ -66,3 +66,5 @@ do_install:append() {
 
 SYSTEMD_SERVICE:${PN} = "iarmbusd.service"
 FILES:${PN} += "${systemd_unitdir}/system/iarmbusd.service"
+FILES:${PN} += "${libdir}/iarm-reboot.sh"
+FILES:${PN} += "${libdir}/iarm-monitor.sh"

--- a/recipes-extended/iarmbus/iarmbus_git.bb
+++ b/recipes-extended/iarmbus/iarmbus_git.bb
@@ -9,9 +9,9 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 PV ?= "1.0.1"
-PR ?= "r0"
+PR ?= "r2"
 
-SRCREV_iarmbus ?= "fbfc891de8644f88cdd7e4a452c06b5a07e98ade"
+SRCREV_iarmbus ?= "98b2a4f2d9cfb2179705ab4fe7ee876a60965cbc"
 SRCREV_FORMAT = "iarmbus"
 SRC_URI = "${CMF_GITHUB_ROOT}/iarmbus;${CMF_GITHUB_SRC_URI_SUFFIX};name=iarmbus"
 
@@ -59,6 +59,9 @@ do_install:append() {
 	install -m 0644 ${S}/core/*.h ${D}${includedir}/rdk/iarmbus
 	install -d ${D}${systemd_unitdir}/system
 	install -m 0644 ${S}/conf/iarmbusd.service ${D}${systemd_unitdir}/system
+	install -d ${D}${libdir}
+	install -m 0755 ${S}/conf/iarm-reboot.sh ${D}${libdir}/
+	install -m 0755 ${S}/conf/iarm-monitor.sh ${D}${libdir}/
 }
 
 SYSTEMD_SERVICE:${PN} = "iarmbusd.service"

--- a/recipes-extended/iarmmgrs/iarmmgrs_git.bb
+++ b/recipes-extended/iarmmgrs/iarmmgrs_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0 & ISC"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=83a31d934b0cc2ab2d44a329445b4366"
 
 PV ?= "1.1.0"
-PR ?= "r2"
+PR ?= "r0"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SAVEDDIR := "${THISDIR}"

--- a/recipes-extended/iarmmgrs/iarmmgrs_git.bb
+++ b/recipes-extended/iarmmgrs/iarmmgrs_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0 & ISC"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=83a31d934b0cc2ab2d44a329445b4366"
 
 PV ?= "1.1.0"
-PR ?= "r0"
+PR ?= "r2"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SAVEDDIR := "${THISDIR}"


### PR DESCRIPTION
Reason for change: Update rebootinfo when dsmgr,iarmbusd crash. Test Procedure: refer RDKEMW-19899
Risks: High
Signed-off-by:gsanto722 <grandhi_santoshkumar@comcast.com>