### PR TITLE
RDKEMW-20104:gst-cleanup conditions when cdl_flashed_file_name is not present

### DIFF
--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -13,7 +13,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/sysint;${CMF_GITHUB_SRC_URI_SUFFIX};module=.;name=
 S = "${WORKDIR}/git"
 
 inherit systemd syslog-ng-config-gen logrotate_config
-SYSLOG-NG_FILTER = " systemd dropbear gstreamer-cleanup update-device-details applications vitalprocess-info iptables mount_log reboot-reason messages zram"
+SYSLOG-NG_FILTER = " systemd dropbear update-device-details applications vitalprocess-info iptables mount_log reboot-reason messages zram"
 SYSLOG-NG_FILTER:append = " ConnectionStats systemd_timesyncd"
 SYSLOG-NG_SERVICE_ConnectionStats = "network-connection-stats.service"
 SYSLOG-NG_DESTINATION_ConnectionStats = "ConnectionStats.txt"
@@ -27,9 +27,6 @@ SYSLOG-NG_LOGRATE_dropbear = "medium"
 SYSLOG-NG_SERVICE_systemd = "init.scope"
 SYSLOG-NG_DESTINATION_systemd = "system.log"
 SYSLOG-NG_LOGRATE_systemd = "high"
-SYSLOG-NG_SERVICE_gstreamer-cleanup = "gstreamer-cleanup.service"
-SYSLOG-NG_DESTINATION_gstreamer-cleanup = "gst-cleanup.log"
-SYSLOG-NG_LOGRATE_gstreamer-cleanup = "low"
 SYSLOG-NG_SERVICE_update-device-details = "update-device-details.service"
 SYSLOG-NG_DESTINATION_update-device-details = "device_details.log"
 SYSLOG-NG_LOGRATE_update-device-details = "low"
@@ -110,7 +107,6 @@ do_install() {
         install -m 0644 ${S}/systemd_units/update-reboot-info.service ${D}${systemd_unitdir}/system
         install -m 0644 ${S}/systemd_units/restart-parodus.path ${D}${systemd_unitdir}/system
         install -m 0644 ${S}/systemd_units/restart-parodus.service ${D}${systemd_unitdir}/system
-        install -m 0644 ${S}/systemd_units/gstreamer-cleanup.service ${D}${systemd_unitdir}/system
         install -m 0644 ${S}/systemd_units/minidump-upload.path ${D}${systemd_unitdir}/system
         install -m 0644 ${S}/systemd_units/minidump-secure-upload.path ${D}${systemd_unitdir}/system
         install -m 0644 ${S}/systemd_units/disk-threshold-check.service ${D}${systemd_unitdir}/system
@@ -122,7 +118,6 @@ do_install() {
         install -m 0644 ${S}/systemd_units/update-reboot-info.service ${D}${systemd_unitdir}/system
         install -m 0644 ${S}/systemd_units/restart-parodus.path ${D}${systemd_unitdir}/system
         install -m 0644 ${S}/systemd_units/restart-parodus.service ${D}${systemd_unitdir}/system
-        install -m 0644 ${S}/systemd_units/gstreamer-cleanup.service ${D}${systemd_unitdir}/system
         install -m 0644 ${S}/systemd_units/oops-dump.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${S}/systemd_units/ntp-event.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${S}/systemd_units/ntp-event.path ${D}${systemd_unitdir}/system
@@ -291,7 +286,6 @@ SYSTEMD_SERVICE:${PN} += "update-reboot-info.path"
 SYSTEMD_SERVICE:${PN} += "update-reboot-info.service"
 SYSTEMD_SERVICE:${PN} += "restart-parodus.path"
 SYSTEMD_SERVICE:${PN} += "restart-parodus.service"
-SYSTEMD_SERVICE:${PN} += "gstreamer-cleanup.service"
 SYSTEMD_SERVICE:${PN} += "ntp-event.service"
 SYSTEMD_SERVICE:${PN} += "ntp-event.path"
 SYSTEMD_SERVICE:${PN} += "network-connection-stats.service"

--- a/recipes-extended/sysint/sysint_git.bb
+++ b/recipes-extended/sysint/sysint_git.bb
@@ -5,10 +5,10 @@ LICENSE = "Apache-2.0 & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f36198fb804ffbe39b5b2c336ceef9f8"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
-PV = "4.5.2v6"
+PV = "4.5.2v7"
 PR = "r0"
 
-SRCREV = "5af604f9039b5c70fd984b1b708faec51c44fecc"
+SRCREV = "d6b7a0c774b032a10e6800c65a0eb68c819c3137"
 SRC_URI = "${CMF_GITHUB_ROOT}/sysint;${CMF_GITHUB_SRC_URI_SUFFIX};module=.;name=sysint"
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/gst-init-service/files/gstreamer-cleanup.service
+++ b/recipes-multimedia/gstreamer/gst-init-service/files/gstreamer-cleanup.service
@@ -1,0 +1,35 @@
+##############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+[Unit]
+Description=Cleans up Gstreamer Registry
+
+After=local-fs.target nvram.service
+Before=wpeframework.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=Yes
+ExecStartPre=/bin/sh -c 'if [ -f /lib/rdk/logMilestone.sh ];then sh /lib/rdk/logMilestone.sh "GST_CLEANUP_START"; fi;'
+ExecStart=-/lib/rdk/gstreamer-cleanup.sh
+ExecStartPost=/bin/sh -c 'if [ -f /lib/rdk/logMilestone.sh ];then sh /lib/rdk/logMilestone.sh "GST_CLEANUP_COMPLETE"; fi;'
+ExecStop=/bin/sh -c 'FW_UPDATE_STATE=$(cat /opt/fwdnldstatus.txt | grep FwUpdateState | cut -d "|" -f2); echo "FW_UPDATE_STATE: $FW_UPDATE_STATE"; if [ "$FW_UPDATE_STATE" == "Preparing to reboot" ]; then  echo "Removing gstreamer registry after firmware update"; rm -rf /opt/.gstreamer; fi;'
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-multimedia/gstreamer/gst-init-service/files/gstreamer-cleanup.sh
+++ b/recipes-multimedia/gstreamer/gst-init-service/files/gstreamer-cleanup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2024 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This script checks if the GStreamer registry should be cleared based on
+# firmware flash status and cleans it if necessary.
+
+# Initialize variables safely
+CDLFILE=""
+PREV_CDLFILE=""
+CUR_IMAGE=""
+
+if [[ -f /opt/cdl_flashed_file_name ]]; then
+    CDLFILE=$(cat /opt/cdl_flashed_file_name)
+fi
+if [[ -f /opt/previous_flashed_file_name ]]; then
+    PREV_CDLFILE=$(cat /opt/previous_flashed_file_name)
+fi
+if [[ -f /version.txt ]]; then
+    CUR_IMAGE=$(grep "^imagename:" /version.txt | cut -d":" -f2)
+fi
+
+# Check all cleanup conditions in a single if statement using bash syntax
+if [[ ! -f /opt/previous_flashed_file_name || \
+      ( ! -f /opt/cdl_flashed_file_name && "${PREV_CDLFILE}" != *"${CUR_IMAGE}"* ) || \
+      ( -f /opt/cdl_flashed_file_name && "${CDLFILE}" != *"${PREV_CDLFILE}"* ) ]]; then
+
+    echo "Removing gstreamer registry on bootup after CDL/FSR"
+    rm -rf /opt/.gstreamer
+    mkdir -p /opt/.gstreamer
+    GST_REGISTRY=/opt/.gstreamer/registry.bin GST_REGISTRY_UPDATE=yes gst-inspect-1.0 >/dev/null 2>&1
+
+elif [[ ! -f /opt/.gstreamer/registry.bin ]]; then
+    # Fallback: Clean if registry file is missing anyway
+    echo "Gstreamer registry empty"
+    rm -rf /opt/.gstreamer
+    mkdir -p /opt/.gstreamer
+    GST_REGISTRY=/opt/.gstreamer/registry.bin GST_REGISTRY_UPDATE=yes gst-inspect-1.0 >/dev/null 2>&1
+else
+    echo "gstreamer registry is not removed, previous reboot is not due to CDL"
+fi

--- a/recipes-multimedia/gstreamer/gst-init-service/gst-init-service_git.bb
+++ b/recipes-multimedia/gstreamer/gst-init-service/gst-init-service_git.bb
@@ -1,0 +1,35 @@
+SUMMARY = "GStreamer registry cleanup service"
+DESCRIPTION = "GStreamer registry cleanup service for post-CDL bootup"
+SECTION = "console/utils"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${THISDIR}/../../../licenses/Apache-2.0;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+PV = "1.0.0"
+PR = "r0"
+
+RDEPENDS:${PN} += "bash"
+
+inherit systemd syslog-ng-config-gen
+
+SYSLOG-NG_FILTER = "gstreamer-cleanup"
+SYSLOG-NG_SERVICE_gstreamer-cleanup = "gstreamer-cleanup.service"
+SYSLOG-NG_DESTINATION_gstreamer-cleanup = "gstreamer_cleanup.log"
+SYSLOG-NG_LOGRATE_gstreamer-cleanup = "low"
+
+SRC_URI += "file://gstreamer-cleanup.sh"
+SRC_URI += "file://gstreamer-cleanup.service"
+
+PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
+
+do_install:append () { 
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/gstreamer-cleanup.service ${D}${systemd_unitdir}/system/gstreamer-cleanup.service
+    install -d ${D}${base_libdir}/rdk
+    install -m 0755 ${WORKDIR}/gstreamer-cleanup.sh ${D}${base_libdir}/rdk/gstreamer-cleanup.sh
+}
+
+SYSTEMD_SERVICE:${PN} = "gstreamer-cleanup.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+FILES:${PN} += "${systemd_unitdir}/system/gstreamer-cleanup.service"
+FILES:${PN} += "${base_libdir}/rdk/gstreamer-cleanup.sh"


### PR DESCRIPTION
Reason for change: gstreamer-cleanup is happening on every reboot when /opt/cdl_flashed_file_name is missing. Fixing the issues as well as re-locating gstreamer-cleanup.service file to recipies-multimedia instead of sysint folder
Test Procedure: Boot the TV and check for gstreamer-cleanup metrics in rdk_milestones.log
Risks: low