### PR TITLE
RDKEMW-18836: Fix the SRCREV of entservices-monitor

### DIFF
--- a/recipes-extended/entservices/entservices-monitor.bb
+++ b/recipes-extended/entservices/entservices-monitor.bb
@@ -8,8 +8,8 @@ PR = "r0"
 S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
-SRCREV = "99041446790c2f310836b3b7a464f4279a1e6cf7"
-SRC_URI = "${CMF_GITHUB_ROOT}/entservices-monitor;${CMF_GITHUB_SRC_URI_SUFFIX}"
+SRCREV = "fdaaa727c8d8c272fc76d610b10a36410fdf7cd8"
+SRC_URI = "${CMF_GITHUB_ROOT}/entservices-monitor;protocol=${CMF_GITHUB_PROTOCOL};branch=main"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
It had gotten merged a little early and was pointing to a feature branch. Also changed SRC_URI to explicitly ask for "main" branch.

Change-Id: I99de4d80b1b94d5c6a399760fdc36db4cb9a7839